### PR TITLE
fix: ssh command detection

### DIFF
--- a/sandbox.ts
+++ b/sandbox.ts
@@ -191,7 +191,7 @@ async function sshIntoSandbox(sandbox: Sandbox): Promise<boolean> {
   const connectInfo = ssh.username + "@" + ssh.hostname;
 
   const which = await new Deno.Command("which", {
-    args: ["ssh_"],
+    args: ["ssh"],
     stdout: "null",
     stderr: "null",
   }).output();


### PR DESCRIPTION
I forgot to revert some debugging change in https://github.com/denoland/deploy-cli/pull/25

(Currently `deno deploy sandbox ssh` and `deno deploy sandbox new` don't automatically open ssh connection because of this bug)