### PR TITLE
fix(sandbox): don't create config file

### DIFF
--- a/sandbox.ts
+++ b/sandbox.ts
@@ -415,10 +415,10 @@ async function ensureOrg(options: SandboxContext, quiet: boolean = true) {
     false,
     options.org ?? configContent.org,
     null,
-    true,
+    quiet,
   );
 
-  if (!configContent.org && app.org) {
+  if (config && !configContent.org && app.org) {
     await writeConfig(config, app.org);
   }
 


### PR DESCRIPTION
We don't want to create a deno.json for sandbox commands, only update one if its present