### PR TITLE
fix: include workspace member files when deploying from workspace root

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,10 @@ jobs:
           submodules: true
 
       - uses: denoland/setup-deno@v2
+        with:
+          # Pinned to avoid Deno 2.7.14 TLS panic in `deno sandbox copy/extend`.
+          # See https://github.com/denoland/deno/issues/33713 — unpin once fixed upstream.
+          deno-version: v2.7.13
 
       - name: fmt
         run: deno fmt --check
@@ -45,6 +49,10 @@ jobs:
         with:
           submodules: true
       - uses: denoland/setup-deno@v2
+        with:
+          # Pinned to avoid Deno 2.7.14 TLS panic in `deno sandbox copy/extend`.
+          # See https://github.com/denoland/deno/issues/33713 — unpin once fixed upstream.
+          deno-version: v2.7.13
       - name: Build
         run: deno task build
       - name: Publish to JSR on tag

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,11 @@ jobs:
 
       - uses: denoland/setup-deno@v2
         with:
-          # Pinned to avoid Deno 2.7.14 TLS panic in `deno sandbox copy/extend`.
-          # See https://github.com/denoland/deno/issues/33713 — unpin once fixed upstream.
-          deno-version: v2.7.13
+          # Pinned to avoid TLS panic in `deno sandbox copy/extend` (regression
+          # present in at least v2.7.13 and v2.7.14; v2.7.8 is the last version
+          # confirmed working). See https://github.com/denoland/deno/issues/33713
+          # — unpin once fixed upstream.
+          deno-version: v2.7.8
 
       - name: fmt
         run: deno fmt --check
@@ -50,9 +52,11 @@ jobs:
           submodules: true
       - uses: denoland/setup-deno@v2
         with:
-          # Pinned to avoid Deno 2.7.14 TLS panic in `deno sandbox copy/extend`.
-          # See https://github.com/denoland/deno/issues/33713 — unpin once fixed upstream.
-          deno-version: v2.7.13
+          # Pinned to avoid TLS panic in `deno sandbox copy/extend` (regression
+          # present in at least v2.7.13 and v2.7.14; v2.7.8 is the last version
+          # confirmed working). See https://github.com/denoland/deno/issues/33713
+          # — unpin once fixed upstream.
+          deno-version: v2.7.8
       - name: Build
         run: deno task build
       - name: Publish to JSR on tag

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
 name = "boxed_error"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -114,9 +120,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "deno_config"
-version = "0.87.0"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9880dc42504a00cf7408f83fccb37386cf478a0900483d033e27ff131f2d8b77"
+checksum = "26bd4881a2385ab360e81e040a9de805d9e5f5cfbea7c345b6a3cd46f02264bb"
 dependencies = [
  "boxed_error",
  "capacity_builder",
@@ -165,15 +171,15 @@ dependencies = [
 
 [[package]]
 name = "deno_maybe_sync"
-version = "0.24.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "358a3f00400c77c4bcf5c32f2f4fb5c67f98439e4b1378a697d508b651cb1cce"
+checksum = "eb2ce6efdde2e0314c3c450eb386a65ccde6497fe4f40d0314c094e32b1bbfc3"
 
 [[package]]
 name = "deno_package_json"
-version = "0.39.0"
+version = "0.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05e9c89551bdc42e670d3bed428aaa7c9ab1cddd6878c4cde463e19d28a28c16"
+checksum = "4d3b3383e1e1e5817312e766374d1bdaa131e00b0bc17ee10f0a448f6db6ef1e"
 dependencies = [
  "boxed_error",
  "capacity_builder",
@@ -246,12 +252,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -278,6 +319,15 @@ name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hipstr"
@@ -377,6 +427,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "idna"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -459,18 +515,30 @@ dependencies = [
 
 [[package]]
 name = "jsonc-parser"
-version = "0.28.0"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b187b7e06feb2c205d8ec71f12cd8f553e33477ec155ebfc34f8daa7f3ae4eab"
+checksum = "8c2e5dea04f54739ca5694ee06e4448ffda065a55b3427d2b131bd5ea697ea2c"
 dependencies = [
- "serde_json",
+ "serde",
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.175"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -527,6 +595,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -543,6 +621,12 @@ checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "regex-automata"
@@ -572,8 +656,22 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen",
  "sys_traits",
+ "tempfile",
  "url",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
@@ -596,6 +694,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -692,9 +796,9 @@ dependencies = [
 
 [[package]]
 name = "sys_traits"
-version = "0.1.24"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5410f31d223892c1ce7a098da845c99d023b4c7f18632bc8f09e60dfae3cbb75"
+checksum = "5a79feaa49de4a6c8191bdbd5fb3eada50671e9367d874d1c12e3d36db131414"
 dependencies = [
  "js-sys",
  "sys_traits_macros",
@@ -710,6 +814,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -749,6 +866,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "url"
 version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -774,6 +897,24 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -832,6 +973,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -915,6 +1090,100 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,12 +6,12 @@ members = [
 
 [workspace.dependencies]
 anyhow = "1.0.57"
-deno_config = "0.87.0"
+deno_config = "0.97.0"
 deno_path_util = "=0.6.4"
 js-sys = "=0.3.77"
 serde = "1.0.149"
 serde-wasm-bindgen = "=0.6.5"
-sys_traits = "0.1.17"
+sys_traits = "0.1.27"
 url = "2.5"
 wasm-bindgen = "=0.2.100"
 

--- a/deno.json
+++ b/deno.json
@@ -17,7 +17,7 @@
   "imports": {
     "@cliffy/command": "jsr:@cliffy/command@^1.0.0",
     "@david/jsonc-morph": "jsr:@david/jsonc-morph@^0.3.1",
-    "@deno/sandbox": "jsr:@deno/sandbox@^0.10.0",
+    "@deno/sandbox": "jsr:@deno/sandbox@^0.13",
     "@std/assert": "jsr:@std/assert@^1.0.16",
     "@std/async": "jsr:@std/async@^1.1.0",
     "@std/cli": "jsr:@std/cli@1.0.27",

--- a/deno.lock
+++ b/deno.lock
@@ -5,19 +5,30 @@
     "jsr:@cliffy/flags@1.0.0": "1.0.0",
     "jsr:@cliffy/internal@1.0.0": "1.0.0",
     "jsr:@cliffy/table@1.0.0": "1.0.0",
+    "jsr:@david/console-static-text@0.3": "0.3.4",
+    "jsr:@david/dax@~0.44.2": "0.44.2",
     "jsr:@david/jsonc-morph@~0.3.1": "0.3.1",
+    "jsr:@david/path@0.2": "0.2.0",
+    "jsr:@david/which@~0.4.1": "0.4.1",
     "jsr:@deno/framework-detect@0.3": "0.3.0",
-    "jsr:@deno/sandbox@0.10": "0.10.1",
+    "jsr:@deno/sandbox@0.13": "0.13.2",
+    "jsr:@std/assert@^1.0.16": "1.0.19",
     "jsr:@std/async@^1.1.0": "1.1.1",
+    "jsr:@std/bytes@^1.0.6": "1.0.6",
     "jsr:@std/cli@1.0.27": "1.0.27",
     "jsr:@std/dotenv@~0.225.5": "0.225.6",
     "jsr:@std/encoding@^1.0.10": "1.0.10",
+    "jsr:@std/fmt@1": "1.0.9",
     "jsr:@std/fmt@^1.0.8": "1.0.9",
     "jsr:@std/fmt@^1.0.9": "1.0.9",
+    "jsr:@std/fs@1": "1.0.23",
     "jsr:@std/fs@^1.0.19": "1.0.23",
+    "jsr:@std/fs@^1.0.20": "1.0.23",
     "jsr:@std/internal@^1.0.12": "1.0.12",
+    "jsr:@std/io@0.225": "0.225.3",
     "jsr:@std/json@^1.0.2": "1.0.2",
     "jsr:@std/jsonc@^1.0.2": "1.0.2",
+    "jsr:@std/path@1": "1.1.4",
     "jsr:@std/path@^1.1.2": "1.1.4",
     "jsr:@std/path@^1.1.4": "1.1.4",
     "jsr:@std/semver@^1.0.8": "1.0.8",
@@ -36,6 +47,7 @@
     "npm:pg-connection-string@^2.9.1": "2.9.1",
     "npm:superjson@^2.2.2": "2.2.6",
     "npm:temporal-polyfill@0.3": "0.3.0",
+    "npm:ws@^8.18.3": "8.20.0",
     "npm:zod@^4.1.5": "4.3.6"
   },
   "jsr": {
@@ -46,6 +58,7 @@
         "jsr:@cliffy/internal",
         "jsr:@cliffy/table",
         "jsr:@std/fmt@^1.0.9",
+        "jsr:@std/semver",
         "jsr:@std/text"
       ]
     },
@@ -65,8 +78,33 @@
         "jsr:@std/fmt@^1.0.9"
       ]
     },
+    "@david/console-static-text@0.3.4": {
+      "integrity": "1c596f500b075ff3c8bab1d328ca7148a88067fd9a506b16a73eeaf230c229fd"
+    },
+    "@david/dax@0.44.2": {
+      "integrity": "26f5985f66a4340d55fb05ca90a0063bb5f0d670a326e14cb33a974aafcbb8d9",
+      "dependencies": [
+        "jsr:@david/console-static-text",
+        "jsr:@david/path",
+        "jsr:@david/which",
+        "jsr:@std/fmt@1",
+        "jsr:@std/fs@^1.0.20",
+        "jsr:@std/io",
+        "jsr:@std/path@1"
+      ]
+    },
     "@david/jsonc-morph@0.3.1": {
       "integrity": "64b0164428146c84b2bebd4a7ea13e4811c209f3ecc8af72b709da9c9a61f03b"
+    },
+    "@david/path@0.2.0": {
+      "integrity": "f2d7aa7f02ce5a55e27c09f9f1381794acb09d328f8d3c8a2e3ab3ffc294dccd",
+      "dependencies": [
+        "jsr:@std/fs@1",
+        "jsr:@std/path@1"
+      ]
+    },
+    "@david/which@0.4.1": {
+      "integrity": "896a682b111f92ab866cc70c5b4afab2f5899d2f9bde31ed00203b9c250f225e"
     },
     "@deno/framework-detect@0.3.0": {
       "integrity": "95aac5d8366e4b007f52adc576e6e3a2abece053f18a7dcb2826ed610c25cb3b",
@@ -75,25 +113,36 @@
         "jsr:@std/path@^1.1.2"
       ]
     },
-    "@deno/sandbox@0.10.1": {
-      "integrity": "98e3b6cd041c019c1af8d6528d02ee4f66d620ac38e62fc27a5db4ecc030ec95",
+    "@deno/sandbox@0.13.2": {
+      "integrity": "c24c7eb9cc00b94954ebffb4ee4f685ef731e6026788044f9eb8a1aa9bfc2cd8",
       "dependencies": [
-        "jsr:@std/fs",
+        "jsr:@std/fs@^1.0.19",
         "jsr:@std/path@^1.1.2",
         "npm:@types/ws",
+        "npm:ws",
         "npm:zod"
       ]
     },
     "@std/assert@1.0.17": {
       "integrity": "df5ebfffe77c03b3fa1401e11c762cc8f603d51021c56c4d15a8c7ab45e90dbe"
     },
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
+      "dependencies": [
+        "jsr:@std/internal"
+      ]
+    },
     "@std/async@1.1.1": {
       "integrity": "8a79beb3378cc229ce65ba2c746cfd03e4855ddd891d1eb6b9e32128e0d5339c"
+    },
+    "@std/bytes@1.0.6": {
+      "integrity": "f6ac6adbd8ccd99314045f5703e23af0a68d7f7e58364b47d2c7f408aeb5820a"
     },
     "@std/cli@1.0.27": {
       "integrity": "eba97edd0891871a7410e835dd94b3c260c709cca5983df2689c25a71fbe04de",
       "dependencies": [
-        "jsr:@std/fmt@^1.0.9"
+        "jsr:@std/fmt@^1.0.9",
+        "jsr:@std/internal"
       ]
     },
     "@std/dotenv@0.225.6": {
@@ -114,6 +163,12 @@
     },
     "@std/internal@1.0.12": {
       "integrity": "972a634fd5bc34b242024402972cd5143eac68d8dffaca5eaa4dba30ce17b027"
+    },
+    "@std/io@0.225.3": {
+      "integrity": "27b07b591384d12d7b568f39e61dff966b8230559122df1e9fd11cc068f7ddd1",
+      "dependencies": [
+        "jsr:@std/bytes"
+      ]
     },
     "@std/json@1.0.2": {
       "integrity": "d9e5497801c15fb679f55a2c01c7794ad7a5dfda4dd1bebab5e409cb5e0d34d4"
@@ -2479,6 +2534,9 @@
         "strip-ansi@7.1.2"
       ]
     },
+    "ws@8.20.0": {
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="
+    },
     "wsl-utils@0.1.0": {
       "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
       "dependencies": [
@@ -2532,7 +2590,7 @@
       "jsr:@david/dax@~0.44.2",
       "jsr:@david/jsonc-morph@~0.3.1",
       "jsr:@deno/framework-detect@0.3",
-      "jsr:@deno/sandbox@0.10",
+      "jsr:@deno/sandbox@0.13",
       "jsr:@std/assert@^1.0.16",
       "jsr:@std/async@^1.1.0",
       "jsr:@std/cli@1.0.27",

--- a/deno.lock
+++ b/deno.lock
@@ -12,7 +12,10 @@
     "jsr:@david/which@~0.4.1": "0.4.1",
     "jsr:@deno/framework-detect@0.3": "0.3.0",
     "jsr:@deno/sandbox@0.13": "0.13.2",
+    "jsr:@deno/sandbox@0.13.2": "0.13.2",
     "jsr:@std/assert@^1.0.16": "1.0.19",
+    "jsr:@std/async@1.1.1": "1.1.1",
+    "jsr:@std/async@1.3.0": "1.3.0",
     "jsr:@std/async@^1.1.0": "1.1.1",
     "jsr:@std/bytes@^1.0.6": "1.0.6",
     "jsr:@std/cli@1.0.27": "1.0.27",
@@ -134,6 +137,9 @@
     },
     "@std/async@1.1.1": {
       "integrity": "8a79beb3378cc229ce65ba2c746cfd03e4855ddd891d1eb6b9e32128e0d5339c"
+    },
+    "@std/async@1.3.0": {
+      "integrity": "80485538a4f7baaa46bfe2246168069e02ed142b9f9079cd164f43bb060ad9e9"
     },
     "@std/bytes@1.0.6": {
       "integrity": "f6ac6adbd8ccd99314045f5703e23af0a68d7f7e58364b47d2c7f408aeb5820a"

--- a/rs_lib/Cargo.toml
+++ b/rs_lib/Cargo.toml
@@ -20,3 +20,6 @@ wasm-bindgen.workspace = true
 [target."cfg(target_arch = \"wasm32\")".dependencies.sys_traits]
 workspace = true
 features = ["real","wasm"]
+
+[dev-dependencies]
+tempfile = "3"

--- a/rs_lib/src/lib.rs
+++ b/rs_lib/src/lib.rs
@@ -151,3 +151,62 @@ fn resolve_absolute_path(path: String) -> Result<PathBuf, anyhow::Error> {
 fn create_js_error(err: &anyhow::Error) -> JsValue {
   wasm_bindgen::JsError::new(&format!("{:#}", err)).into()
 }
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+  use super::inner_resolve_config;
+  use std::fs;
+  use std::path::Path;
+  use tempfile::TempDir;
+
+  fn write_file(root: &Path, rel: &str, contents: &str) {
+    let path = root.join(rel);
+    if let Some(parent) = path.parent() {
+      fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(path, contents).unwrap();
+  }
+
+  // Regression test for denoland/deno#33562: running `deno deploy` from a
+  // workspace root with a top-level `deploy` config must include workspace
+  // member files in the upload manifest. Before the fix this returned an
+  // empty file list because members were silently appended to the exclude
+  // patterns.
+  #[test]
+  fn workspace_root_includes_member_files() {
+    let temp = TempDir::new().unwrap();
+    let root = temp.path();
+    write_file(
+      root,
+      "deno.json",
+      r#"{
+        "workspace": ["./packages/backend"],
+        "deploy": { "org": "myorg", "app": "myapp" }
+      }"#,
+    );
+    write_file(root, "packages/backend/deno.json", "{}");
+    write_file(
+      root,
+      "packages/backend/main.ts",
+      "Deno.serve(() => new Response('hello'));",
+    );
+
+    let result = inner_resolve_config(
+      root.to_string_lossy().into_owned(),
+      Vec::new(),
+      false,
+    )
+    .unwrap();
+
+    let expected = root.join("packages/backend/main.ts");
+    assert!(
+      result
+        .files
+        .iter()
+        .any(|f| Path::new(f) == expected.as_path()),
+      "expected {} in deploy files; got {:?}",
+      expected.display(),
+      result.files,
+    );
+  }
+}

--- a/sandbox/mod.ts
+++ b/sandbox/mod.ts
@@ -356,7 +356,7 @@ export const sandboxCopyCommand = new Command<SandboxContext>()
                 const tempDir = await Deno.makeTempDir();
 
                 await Array.fromAsync(pooledMap(
-                  Infinity,
+                  Number.MAX_SAFE_INTEGER,
                   sourceSandbox.fs.expandGlob(sourceSandboxPath),
                   async (sandboxEntry) => {
                     const tempPath = join(tempDir, sandboxEntry.path);
@@ -367,7 +367,7 @@ export const sandboxCopyCommand = new Command<SandboxContext>()
                     );
 
                     await Array.fromAsync(pooledMap(
-                      Infinity,
+                      Number.MAX_SAFE_INTEGER,
                       expandGlob(`${tempPath}/*`),
                       (localEntry) =>
                         targetSandbox.fs.upload(
@@ -415,7 +415,7 @@ export const sandboxCopyCommand = new Command<SandboxContext>()
 
           await Promise.all(sandboxPaths.map(async (sandboxPath) => {
             await Array.fromAsync(pooledMap(
-              Infinity,
+              Number.MAX_SAFE_INTEGER,
               sandbox.fs.expandGlob(sandboxPath),
               (entry) => sandbox.fs.download(entry.path, target),
             ));


### PR DESCRIPTION
Fixes the bug where `deno deploy` from a workspace root with a top-level `deploy` config produced a near-empty upload manifest, surfacing as errors like `Working directory at 'packages/backend' not found`.

The root cause is in `deno_config::WorkspaceDirectory::to_deploy_config`, which appended every workspace member directory to the file-pattern exclude list. That behavior is correct for `lint`/`fmt`/`publish` (each member owns its own config) but wrong for `deploy`, which needs to upload the whole tree. Fixed upstream in denoland/deno#33562 and shipped in `deno_config@0.97.0`.
