### PR TITLE
fix: (os error 123): readfile '/C:/path/to/project/index.ts'

### DIFF
--- a/rs_lib/src/lib.rs
+++ b/rs_lib/src/lib.rs
@@ -211,7 +211,7 @@ fn collect_files(
   let collected: Vec<String> = collector
     .collect_file_patterns(real_sys, &files)
     .into_iter()
-    .map(|path| path.to_string_lossy().to_string())
+    .map(|path| sys_traits::impls::wasm_path_to_str(&path).into_owned())
     .collect();
 
   debug_log(


### PR DESCRIPTION
Fixes the bug where `deno deploy` on Windows fails to upload any file, surfacing as `(os error 123): readfile '/C:/path/to/project/index.ts'`.

```powershell
C:\path\to\project> deno deploy --prod --org=bacek97 --app=app .
⠋ Publishing 'C:\path\to\project'
✗ An error occurred:
  Синтаксическая ошибка в имени файла, имени папки или метке тома. (os error 123): readfile '/C:/path/to/project/index.ts'
```

The root cause is in `collect_files`, which returned file paths to JS via `path.to_string_lossy()`. Because `rs_lib` is compiled to `wasm32-unknown-unknown`, `PathBuf` uses Unix separators and `sys_traits::wasm_string_to_path` rewrites Windows absolute paths to a Unix-like form (`C:\foo` → `/C:/foo`) when crossing into WASM. Every other path leaving WASM goes through `sys_traits::wasm_path_to_str`, which reverses that rewrite — but `collect_files` skipped it, so JS received `/C:/...` strings and passed them straight to `Deno.readFile`.