### PR TITLE
fix(config): preserve other deploy fields when writing org/app

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -297,15 +297,25 @@ async function writeConfig(
 
   const content = configContent.config?.content ?? "{}\n";
 
-  const newConfig: Record<string, string> = { org };
-
-  if (app) {
-    newConfig.app = app;
-  }
-
   const config = parseJSONC(content);
   const deployObj = config.asObjectOrForce().getIfObjectOrForce("deploy");
-  deployObj.replaceWith(newConfig);
+
+  const upsertKey = (key: string, value: string) => {
+    const prop = deployObj.get(key);
+    if (prop) {
+      prop.setValue(value);
+    } else {
+      deployObj.append(key, value);
+    }
+  };
+
+  upsertKey("org", org);
+  if (app) {
+    upsertKey("app", app);
+  } else {
+    deployObj.get("app")?.remove();
+  }
+
   deployObj.ensureMultiline();
 
   await Deno.writeTextFile(

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,0 +1,96 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { join } from "@std/path";
+import { actionHandler } from "../config.ts";
+import type { GlobalContext } from "../main.ts";
+
+// Runs the deploy action handler on a temporary config
+async function runDeploy(
+  content: string,
+  resolved: { org: string | undefined; app: string | undefined },
+): Promise<string> {
+  const dir = await Deno.makeTempDir();
+  const path = join(dir, "deno.json");
+  try {
+    await Deno.writeTextFile(path, content);
+    const context = {
+      config: path,
+      ignore: [],
+      allowNodeModules: false,
+      debug: false,
+    } as unknown as GlobalContext;
+
+    await actionHandler((config) => {
+      config.org = resolved.org;
+      config.app = resolved.app;
+    })(context);
+
+    return await Deno.readTextFile(path);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+Deno.test("deploy preserves other deploy fields when persisting org/app", async () => {
+  const input = `{
+  "deploy": {
+    "org": "old-org",
+    "app": "old-app",
+    "exclude": ["!dist"],
+    "framework": "fresh"
+  }
+}
+`;
+  const outputConfigJson = await runDeploy(input, {
+    org: "my-org",
+    app: "my-app",
+  });
+  const outputConfig = JSON.parse(outputConfigJson);
+
+  assertEquals(outputConfig.deploy.org, "my-org");
+  assertEquals(outputConfig.deploy.app, "my-app");
+  assertEquals(outputConfig.deploy.exclude, ["!dist"]);
+  assertEquals(outputConfig.deploy.framework, "fresh");
+});
+
+Deno.test("deploy creates the deploy block when the config has none", async () => {
+  const outputConfigJson = await runDeploy("{}\n", {
+    org: "my-org",
+    app: "my-app",
+  });
+  const outputConfig = JSON.parse(outputConfigJson);
+
+  assertEquals(outputConfig.deploy.org, "my-org");
+  assertEquals(outputConfig.deploy.app, "my-app");
+});
+
+Deno.test("deploy clears app when it doesn't resolve but keeps siblings", async () => {
+  const input = `{
+  "deploy": { "org": "old-org", "app": "stale", "exclude": ["!dist"] }
+}
+`;
+
+  const outputConfigJson = await runDeploy(input, {
+    org: "my-org",
+    app: undefined,
+  });
+  const out = JSON.parse(outputConfigJson);
+
+  assertEquals(out.deploy.app, undefined);
+  assertEquals(out.deploy.exclude, ["!dist"]);
+});
+
+Deno.test("deploy preserves comments and formatting (jsonc)", async () => {
+  const input = `{
+  // keep this comment
+  "deploy": {
+    "org": "old-org", // and this one
+    "exclude": ["!dist"]
+  }
+}
+`;
+
+  const out = await runDeploy(input, { org: "my-org", app: undefined });
+
+  assertStringIncludes(out, "// keep this comment");
+  assertStringIncludes(out, "// and this one");
+});


### PR DESCRIPTION
# Summary

## Problem

`deno deploy` updates the `org` and `app` fields in the config. However, it doesn't preserve other fields in the `deploy` block.

For example, after running `deno deploy` this config:

```json
 "deploy": {
    "org": "my-org",
    "app": "my-app",
    "exclude": [
      "!dist"
    ]
  }
```

becomes just 

```json
  "deploy": {
    "org": "vlcdn",
    "app": "parkruns"
  }
```

## Changes

The solution is to update the `org` and `app` fields directly rather than replacing the entire `deploy` block.

## Tests

Since `writeConfig` is not exported, the new behaviour is tested via executing the deploy handler.