### PR TITLE
fix(database): make `database link` usable (crash + port type + payload key)

### DIFF
--- a/deploy/database.ts
+++ b/deploy/database.ts
@@ -89,19 +89,10 @@ const databasesLinkCommand = new Command<DatabaseContext>()
     "Test connection without linking",
     "link --dry-run my-db --hostname db.example.com",
   )
-  .option("--hostname <string>", "The hostname to use for the database", {
-    required: true,
-    conflicts: ["connectionString"],
-  })
-  .option("--username <string>", "The username to use for the database", {
-    conflicts: ["connectionString"],
-  })
-  .option("--password <string>", "The password to use for the database", {
-    conflicts: ["connectionString"],
-  })
-  .option("--port <number>", "The port to use for the database", {
-    conflicts: ["connectionString"],
-  })
+  .option("--hostname <string>", "The hostname to use for the database")
+  .option("--username <string>", "The username to use for the database")
+  .option("--password <string>", "The password to use for the database")
+  .option("--port <number>", "The port to use for the database")
   .option("--cert <string>", "The SSL certificate to use for the database")
   .option(
     "--dry-run",
@@ -110,6 +101,23 @@ const databasesLinkCommand = new Command<DatabaseContext>()
   .arguments("<name:string> [connectionString:string]")
   .action(actionHandler(async (config, options, name, connectionString) => {
     config.noCreate();
+
+    // `connectionString` is a positional argument, so its mutual exclusion
+    // with --hostname/--port/--username/--password can't be expressed via
+    // cliffy's `conflicts` (which only accepts option names). Validate manually.
+    const hasIndividualFlags = options.hostname || options.port !== undefined ||
+      options.username || options.password;
+    if (connectionString && hasIndividualFlags) {
+      throw new TypeError(
+        "Provide either a connection string or the individual " +
+          "--hostname/--port/--username/--password flags, not both.",
+      );
+    }
+    if (!connectionString && !options.hostname) {
+      throw new TypeError(
+        "A connection string or --hostname is required.",
+      );
+    }
 
     const org = await getOrg(options, config, options.org);
     const trpcClient = createTrpcClient(options);
@@ -152,7 +160,9 @@ const databasesLinkCommand = new Command<DatabaseContext>()
 
     const connectionConfig = {
       hostname: hostname,
-      port: port || null,
+      // The backend expects a number; `--port <number>` and the parsed
+      // connection-string port both arrive as strings, so coerce here.
+      port: port != null ? Number(port) : null,
       username: username || null,
       password: password || null,
       certificate: options.cert || null,

--- a/deploy/database.ts
+++ b/deploy/database.ts
@@ -180,7 +180,7 @@ const databasesLinkCommand = new Command<DatabaseContext>()
         org: org,
         slug: name,
         engine,
-        connectionConfig,
+        connection_config: connectionConfig,
       });
       console.log(`${green("✔")} Successfully linked database '${name}'.`);
     }


### PR DESCRIPTION
## What

`deno deploy database link` is currently unusable. This makes it work end to end. It turned out to be **three** distinct bugs, each blocking the one after it.

Fixes #104.

## Bug 1 — unconditional crash
`--hostname/--username/--password/--port` are declared `conflicts: ["connectionString"]`, but `connectionString` is a **positional argument**, not an option. Cliffy's `conflicts` only accepts option names, so validation throws `Unknown conflicting option "connectionString"` before any input is processed — every form crashes, including `database link --help`.

Fix: remove the invalid `conflicts` (and the `required: true` on `--hostname`, which otherwise makes the connection-string form impossible), and validate the connection-string-vs-flags mutual exclusion manually in the action.

## Bug 2 — port sent as a string
With the crash fixed, the backend rejects the request: `port: expected number, received string`. Both `--port <number>` (cliffy treats `<number>` as a value label, not a type coercion) and the parsed connection-string port arrive as strings. Fix: coerce `port` to a number when building `connectionConfig`.

## Bug 3 — wrong payload key for createInstance
With ports fixed, `--dry-run` succeeds but a real link still fails with `connection_config: expected object, received undefined`. The dry-run path sends `connection_config` (snake_case) to `databases.testConnection`, but the link path sent `connectionConfig` (camelCase) to `databases.createInstance`. The backend expects snake_case. Fix: use `connection_config` in the createInstance call too.

## Verification
Against a real Postgres, all paths now work:

```
$ deno run -A main.ts database link --dry-run my-db --hostname db.example.com --port 5432 --username u --password '***'
✔ Connection test successful.

$ deno run -A main.ts database link --dry-run my-db "postgresql://u:***@db.example.com:5432/db"
✔ Connection test successful.

$ deno run -A main.ts database link my-db "postgresql://u:***@db.example.com:5432/db"
✔ Successfully linked database 'my-db'.
```

`deno fmt` and `deno lint` pass on the changed file.
