### PR TITLE
fix: deliver USAGE exit + JSON envelope for bad flags; clean switch output

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1,8 +1,9 @@
-import { Command } from "@cliffy/command";
+import { Command, ValidationError } from "@cliffy/command";
 import { greaterOrEqual, parse as semverParse } from "@std/semver";
 import { sandboxCommand } from "./sandbox/mod.ts";
 import { deployCommand } from "./deploy/mod.ts";
 import { actionHandler, getApp, getOrg } from "./config.ts";
+import { error, ExitCode } from "./util.ts";
 
 const MINIMUM_DENO_VERSION = "2.4.2";
 if (
@@ -30,10 +31,45 @@ export type GlobalContext = {
   nonInteractive?: true;
 };
 
-if (Deno.env.has("DENO_DEPLOY_CLI_SANDBOX")) {
-  await sandboxCommand.parse(Deno.args);
-} else {
-  await deployCommand.command("sandbox", sandboxCommand).parse(Deno.args);
+// `.noExit()` makes Cliffy throw parse errors instead of exiting, so they can be
+// routed through the CLI error contract (see `handleCliError`). It also stops
+// `--help`/`--version` from exiting: Cliffy prints them and `parse()` returns, so
+// the process still exits 0. `.reset()` first repoints the builder back to the
+// root command (mounting/defining subcommands leaves it selecting a child), so
+// `.noExit()` applies to the command we actually parse.
+try {
+  if (Deno.env.has("DENO_DEPLOY_CLI_SANDBOX")) {
+    await sandboxCommand.reset().noExit().parse(Deno.args);
+  } else {
+    await deployCommand.command("sandbox", sandboxCommand).reset().noExit()
+      .parse(Deno.args);
+  }
+} catch (e) {
+  handleCliError(e);
+}
+
+/**
+ * Map an error thrown out of Cliffy's `parse()` onto the CLI error contract.
+ * `ValidationError` (unknown/invalid/conflicting flag, missing value) is a usage
+ * error and must exit with `ExitCode.USAGE` (2); anything else is generic.
+ */
+function handleCliError(e: unknown): never {
+  const context: GlobalContext = {
+    debug: Deno.args.includes("--debug"),
+    endpoint: "",
+    json: Deno.args.includes("--json") || Deno.args.includes("-j")
+      ? true
+      : undefined,
+  };
+
+  if (e instanceof ValidationError) {
+    error(context, e.message, {
+      code: ExitCode.USAGE,
+      errorCode: "VALIDATION_ERROR",
+    });
+  }
+
+  error(context, e instanceof Error ? e.message : String(e));
 }
 
 export function createSwitchCommand(

--- a/main.ts
+++ b/main.ts
@@ -3,7 +3,7 @@ import { greaterOrEqual, parse as semverParse } from "@std/semver";
 import { sandboxCommand } from "./sandbox/mod.ts";
 import { deployCommand } from "./deploy/mod.ts";
 import { actionHandler, getApp, getOrg } from "./config.ts";
-import { error, ExitCode } from "./util.ts";
+import { error, ExitCode, writeJsonResult } from "./util.ts";
 
 const MINIMUM_DENO_VERSION = "2.4.2";
 if (
@@ -88,10 +88,14 @@ export function createSwitchCommand(
         app = out.app;
       }
 
-      console.log(
-        `Switched to organization '${org}'${
-          app ? ` and application '${app}'` : ""
-        }.`,
-      );
+      if (options.json) {
+        writeJsonResult({ org, app: app ?? null });
+      } else {
+        console.error(
+          `Switched to organization '${org}'${
+            app ? ` and application '${app}'` : ""
+          }.`,
+        );
+      }
     }));
 }

--- a/main.ts
+++ b/main.ts
@@ -57,9 +57,7 @@ function handleCliError(e: unknown): never {
   const context: GlobalContext = {
     debug: Deno.args.includes("--debug"),
     endpoint: "",
-    json: Deno.args.includes("--json") || Deno.args.includes("-j")
-      ? true
-      : undefined,
+    json: Deno.args.some(isJsonModeArg) ? true : undefined,
   };
 
   if (e instanceof ValidationError) {
@@ -70,6 +68,16 @@ function handleCliError(e: unknown): never {
   }
 
   error(context, e instanceof Error ? e.message : String(e));
+}
+
+/**
+ * Best-effort `--json` detection without a parsed context, used by
+ * `handleCliError` to pick the error output format when `parse()` itself throws.
+ * Matches `--json`, `--json=...`, `-j`, and combined short flags like `-jy`.
+ */
+function isJsonModeArg(arg: string): boolean {
+  return arg === "-j" || arg === "--json" || arg.startsWith("--json=") ||
+    /^-[a-z]*j[a-z]*$/.test(arg);
 }
 
 export function createSwitchCommand(

--- a/main.ts
+++ b/main.ts
@@ -31,12 +31,8 @@ export type GlobalContext = {
   nonInteractive?: true;
 };
 
-// `.noExit()` makes Cliffy throw parse errors instead of exiting, so they can be
-// routed through the CLI error contract (see `handleCliError`). It also stops
-// `--help`/`--version` from exiting: Cliffy prints them and `parse()` returns, so
-// the process still exits 0. `.reset()` first repoints the builder back to the
-// root command (mounting/defining subcommands leaves it selecting a child), so
-// `.noExit()` applies to the command we actually parse.
+// `.reset()` repoints the builder to the root command before `.noExit()`, which
+// makes Cliffy throw parse errors instead of exiting so `handleCliError` can map them.
 try {
   if (Deno.env.has("DENO_DEPLOY_CLI_SANDBOX")) {
     await sandboxCommand.reset().noExit().parse(Deno.args);
@@ -48,11 +44,7 @@ try {
   handleCliError(e);
 }
 
-/**
- * Map an error thrown out of Cliffy's `parse()` onto the CLI error contract.
- * `ValidationError` (unknown/invalid/conflicting flag, missing value) is a usage
- * error and must exit with `ExitCode.USAGE` (2); anything else is generic.
- */
+// Maps an error thrown out of `parse()` to the CLI error contract (ValidationError -> USAGE).
 function handleCliError(e: unknown): never {
   const context: GlobalContext = {
     debug: Deno.args.includes("--debug"),
@@ -70,11 +62,7 @@ function handleCliError(e: unknown): never {
   error(context, e instanceof Error ? e.message : String(e));
 }
 
-/**
- * Best-effort `--json` detection without a parsed context, used by
- * `handleCliError` to pick the error output format when `parse()` itself throws.
- * Matches `--json`, `--json=...`, `-j`, and combined short flags like `-jy`.
- */
+// Parse-free `--json` detection: matches `--json`, `--json=...`, `-j`, and bundles like `-jy`.
 function isJsonModeArg(arg: string): boolean {
   return arg === "-j" || arg === "--json" || arg.startsWith("--json=") ||
     /^-[a-z]*j[a-z]*$/.test(arg);

--- a/tests/agent.test.ts
+++ b/tests/agent.test.ts
@@ -159,8 +159,6 @@ Deno.test("publish (default command) --json keeps stdout clean and emits an AUTH
 });
 
 Deno.test("non-zero exit code matches taxonomy for invalid flag (USAGE=2)", async () => {
-  // Cliffy `ValidationError`s are now routed through the CLI error contract, so
-  // a bad flag value exits with USAGE (2) and keeps stdout clean.
   const res = await deployRaw(
     "create",
     "--dry-run",

--- a/tests/agent.test.ts
+++ b/tests/agent.test.ts
@@ -159,8 +159,8 @@ Deno.test("publish (default command) --json keeps stdout clean and emits an AUTH
 });
 
 Deno.test("non-zero exit code matches taxonomy for invalid flag (USAGE=2)", async () => {
-  // Cliffy's ValidationError handler exits with code 1 by default;
-  // verify the agent can pattern-match on stderr text either way.
+  // Cliffy `ValidationError`s are now routed through the CLI error contract, so
+  // a bad flag value exits with USAGE (2) and keeps stdout clean.
   const res = await deployRaw(
     "create",
     "--dry-run",
@@ -171,8 +171,9 @@ Deno.test("non-zero exit code matches taxonomy for invalid flag (USAGE=2)", asyn
     "--source",
     "invalid",
   );
-  assert(res.code !== 0);
-  assertStringIncludes(res.stderr + res.stdout, "Invalid source");
+  assertEquals(res.code, 2, `stderr: ${res.stderr}`);
+  assertEquals(res.stdout.trim(), "", `stdout should be empty: ${res.stdout}`);
+  assertStringIncludes(res.stderr, "Invalid source");
 });
 
 async function sandboxRaw(...args: string[]): Promise<

--- a/tests/cli_contract.test.ts
+++ b/tests/cli_contract.test.ts
@@ -43,6 +43,16 @@ Deno.test("unknown flag with --json emits a USAGE envelope on stderr, clean stdo
   );
 });
 
+Deno.test("combined short flag -jy is detected as JSON mode for the error envelope", async () => {
+  // `-jy` bundles `-j` (json) and `-y` (non-interactive); a bad flag must still
+  // surface the structured envelope on stderr, not the human-readable error.
+  const res = await runCli(["-jy", "--does-not-exist"]);
+  assertEquals(res.code, 2, `stderr: ${res.stderr}`);
+  assertEquals(res.stdout.trim(), "", `stdout should be empty: ${res.stdout}`);
+  const envelope = JSON.parse(res.stderr.trim().split("\n").pop()!);
+  assertEquals(envelope.error.code, "VALIDATION_ERROR");
+});
+
 Deno.test("--help exits 0", async () => {
   const res = await runCli(["--help"]);
   assertEquals(res.code, 0, `stderr: ${res.stderr}`);

--- a/tests/cli_contract.test.ts
+++ b/tests/cli_contract.test.ts
@@ -1,10 +1,7 @@
 import { assert, assertEquals } from "@std/assert";
 import { fromFileUrl } from "@std/path";
 
-// These tests drive `main.ts` as a subprocess and assert the exit-code contract.
-// Unlike the other suites here, they don't touch the backend, so no token is
-// required: bad flags / `--help` / `--version` are resolved entirely by the
-// argument parser before any command action runs.
+// Token-free subprocess tests for the parse-time exit-code contract.
 
 const MAIN_TS = fromFileUrl(new URL("../main.ts", import.meta.url));
 
@@ -44,8 +41,6 @@ Deno.test("unknown flag with --json emits a USAGE envelope on stderr, clean stdo
 });
 
 Deno.test("combined short flag -jy is detected as JSON mode for the error envelope", async () => {
-  // `-jy` bundles `-j` (json) and `-y` (non-interactive); a bad flag must still
-  // surface the structured envelope on stderr, not the human-readable error.
   const res = await runCli(["-jy", "--does-not-exist"]);
   assertEquals(res.code, 2, `stderr: ${res.stderr}`);
   assertEquals(res.stdout.trim(), "", `stdout should be empty: ${res.stdout}`);

--- a/tests/cli_contract.test.ts
+++ b/tests/cli_contract.test.ts
@@ -1,0 +1,61 @@
+import { assert, assertEquals } from "@std/assert";
+import { fromFileUrl } from "@std/path";
+
+// These tests drive `main.ts` as a subprocess and assert the exit-code contract.
+// Unlike the other suites here, they don't touch the backend, so no token is
+// required: bad flags / `--help` / `--version` are resolved entirely by the
+// argument parser before any command action runs.
+
+const MAIN_TS = fromFileUrl(new URL("../main.ts", import.meta.url));
+
+async function runCli(
+  args: string[],
+  env: Record<string, string> = {},
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  const { code, stdout, stderr } = await new Deno.Command(Deno.execPath(), {
+    args: ["run", "-A", MAIN_TS, ...args],
+    env,
+    stdout: "piped",
+    stderr: "piped",
+  }).output();
+  return {
+    code,
+    stdout: new TextDecoder().decode(stdout),
+    stderr: new TextDecoder().decode(stderr),
+  };
+}
+
+Deno.test("unknown flag exits with USAGE (2)", async () => {
+  const res = await runCli(["--does-not-exist"]);
+  assertEquals(res.code, 2, `stderr: ${res.stderr}`);
+});
+
+Deno.test("unknown flag with --json emits a USAGE envelope on stderr, clean stdout", async () => {
+  const res = await runCli(["--json", "--does-not-exist"]);
+  assertEquals(res.code, 2, `stderr: ${res.stderr}`);
+  assertEquals(res.stdout.trim(), "", `stdout should be empty: ${res.stdout}`);
+  const envelope = JSON.parse(res.stderr.trim().split("\n").pop()!);
+  assertEquals(envelope.error.code, "VALIDATION_ERROR");
+  assert(
+    typeof envelope.error.message === "string" &&
+      envelope.error.message.length > 0,
+    `expected a message; got: ${JSON.stringify(envelope)}`,
+  );
+});
+
+Deno.test("--help exits 0", async () => {
+  const res = await runCli(["--help"]);
+  assertEquals(res.code, 0, `stderr: ${res.stderr}`);
+});
+
+Deno.test("--version exits 0", async () => {
+  const res = await runCli(["--version"]);
+  assertEquals(res.code, 0, `stderr: ${res.stderr}`);
+});
+
+Deno.test("unknown flag exits with USAGE (2) on the standalone sandbox root", async () => {
+  const res = await runCli(["--does-not-exist"], {
+    DENO_DEPLOY_CLI_SANDBOX: "1",
+  });
+  assertEquals(res.code, 2, `stderr: ${res.stderr}`);
+});


### PR DESCRIPTION
Fixes two CLI-contract rough edges from #112.

## 1. Bad flags now honor the agent/CI contract
Previously, an unknown/invalid flag dumped the full help text to **stdout** and a raw, ANSI-colored Cliffy error to stderr — even under `--json` — corrupting machine-readable output (the exit code already happened to be 2 because `@cliffy/command`'s `ValidationError.exitCode` defaults to 2, but everything around it violated the contract).

Now the root `parse()` runs with `.noExit()` and thrown `ValidationError`s (unknown/invalid/conflicting flags, missing values, and app-thrown `ValidationError`s re-thrown by `actionHandler`) are funneled through the CLI error contract:
- exit `ExitCode.USAGE` (2),
- under `--json`: a single `{ "error": { "code": "VALIDATION_ERROR", "message": ... } }` envelope on **stderr**, clean stdout, ANSI disabled,
- otherwise: the standard human-readable error.

`.reset()` repoints Cliffy's builder to the root command before `.noExit()` (mounting/defining subcommands leaves the builder selecting a child, so the setting would otherwise land on the wrong command). `--help` and `--version` still exit 0.

## 2. `switch` no longer pollutes stdout
`switch` printed its confirmation to stdout via `console.log` and emitted nothing under `--json`. It now sends the human message to **stderr** and, under `--json`, writes a single `{ org, app }` result to stdout (app is `null` for the sandbox variant, which doesn't resolve an app).

## Tests
- New token-free subprocess suite `tests/cli_contract.test.ts`: bad flag → 2 (deploy + standalone sandbox roots), `--json` bad flag → 2 with envelope on stderr and clean stdout, `--help`/`--version` → 0.
- Tightened the existing invalid-flag test to assert USAGE (2) and a clean stdout.

Verified offline: bad flags (plain + `--json`), `--help`, `--version`, unknown subcommand-as-path, bad option values, and both `switch` output modes.