### PR TITLE
feat(database): expose KV connect database id; fix --json stdout discipline

### DIFF
--- a/deploy/database.ts
+++ b/deploy/database.ts
@@ -15,8 +15,16 @@ export type DatabaseContext = GlobalContext & {
   org?: string;
 };
 
-function kvConnectUrl(databaseId: string): string {
-  return `https://api.deno.com/v2/databases/${databaseId}/connect`;
+// KV connect is served from api.deno.com, which has no configurable
+// counterpart to --endpoint/DENO_DEPLOY_ENDPOINT; suppress the URL for
+// non-default endpoints so a staging database id is never pointed at prod.
+function kvConnectUrl(
+  endpoint: string,
+  databaseId: string,
+): string | undefined {
+  return endpoint === "https://console.deno.com"
+    ? `https://api.deno.com/v2/databases/${databaseId}/connect`
+    : undefined;
 }
 
 const databasesProvisionCommand = new Command<DatabaseContext>()
@@ -100,7 +108,7 @@ const databasesLinkCommand = new Command<DatabaseContext>()
   .option("--hostname <string>", "The hostname to use for the database")
   .option("--username <string>", "The username to use for the database")
   .option("--password <string>", "The password to use for the database")
-  .option("--port <number>", "The port to use for the database")
+  .option("--port <port:number>", "The port to use for the database")
   .option("--cert <string>", "The SSL certificate to use for the database")
   .option(
     "--dry-run",
@@ -116,13 +124,13 @@ const databasesLinkCommand = new Command<DatabaseContext>()
     const hasIndividualFlags = options.hostname || options.port !== undefined ||
       options.username || options.password;
     if (connectionString && hasIndividualFlags) {
-      throw new TypeError(
+      throw new ValidationError(
         "Provide either a connection string or the individual " +
           "--hostname/--port/--username/--password flags, not both.",
       );
     }
     if (!connectionString && !options.hostname) {
-      throw new TypeError(
+      throw new ValidationError(
         "A connection string or --hostname is required.",
       );
     }
@@ -142,7 +150,7 @@ const databasesLinkCommand = new Command<DatabaseContext>()
         !connectionString.startsWith("postgres://") &&
         !connectionString.startsWith("postgresql://")
       ) {
-        throw new TypeError(
+        throw new ValidationError(
           "Invalid connection string, expected postgres:// or postgresql:// prefix.",
         );
       }
@@ -168,8 +176,8 @@ const databasesLinkCommand = new Command<DatabaseContext>()
 
     const connectionConfig = {
       hostname: hostname,
-      // The backend expects a number; `--port <number>` and the parsed
-      // connection-string port both arrive as strings, so coerce here.
+      // The backend expects a number; the parsed connection-string port
+      // arrives as a string, so coerce here.
       port: port != null ? Number(port) : null,
       username: username || null,
       password: password || null,
@@ -387,13 +395,15 @@ const databasesListCommand = new Command<DatabaseContext>()
         connection: database.safeConnectionConfig,
         databases: database.databases.map((db) => {
           const databaseId = db.metadata?.td_id;
+          const connectUrl = databaseId
+            ? kvConnectUrl(options.endpoint, databaseId)
+            : undefined;
           return {
             name: db.name,
             status: db.status,
             createdAt: db.created_at,
-            ...(databaseId
-              ? { databaseId, connectUrl: kvConnectUrl(databaseId) }
-              : {}),
+            ...(databaseId ? { databaseId } : {}),
+            ...(connectUrl ? { connectUrl } : {}),
           };
         }),
       })));

--- a/deploy/database.ts
+++ b/deploy/database.ts
@@ -81,7 +81,7 @@ const databasesProvisionCommand = new Command<DatabaseContext>()
     });
 
     if (options.json) {
-      writeJsonResult({ name, engine: options.kind, org });
+      writeJsonResult({ database: name, engine: options.kind, org });
     } else {
       console.error(
         `${
@@ -177,7 +177,7 @@ const databasesLinkCommand = new Command<DatabaseContext>()
         connection_config: connectionConfig,
       });
       if (options.json) {
-        writeJsonResult({ name, engine, dryRun: true, ok: true });
+        writeJsonResult({ database: name, engine, dryRun: true, ok: true });
       } else {
         console.error(`${green("✔")} Connection test successful.`);
       }
@@ -189,7 +189,7 @@ const databasesLinkCommand = new Command<DatabaseContext>()
         connectionConfig,
       });
       if (options.json) {
-        writeJsonResult({ name, engine, org });
+        writeJsonResult({ database: name, engine, org });
       } else {
         console.error(`${green("✔")} Successfully linked database '${name}'.`);
       }
@@ -443,7 +443,7 @@ const databasesDeleteCommand = new Command<DatabaseContext>()
     });
 
     if (options.json) {
-      writeJsonResult({ name, org });
+      writeJsonResult({ database: name, org });
     } else {
       console.error(`${green("✔")} Successfully deleted database '${name}'.`);
     }

--- a/deploy/database.ts
+++ b/deploy/database.ts
@@ -15,6 +15,14 @@ export type DatabaseContext = GlobalContext & {
   org?: string;
 };
 
+/**
+ * Build the Deno KV connect URL for a per-environment database id, suitable for
+ * `Deno.openKv("https://api.deno.com/v2/databases/<id>/connect")`.
+ */
+function kvConnectUrl(databaseId: string): string {
+  return `https://api.deno.com/v2/databases/${databaseId}/connect`;
+}
+
 const databasesProvisionCommand = new Command<DatabaseContext>()
   .description("Provision a database")
   .example("Provision a Deno KV database", "provision my-db --kind denokv")
@@ -332,7 +340,12 @@ const databasesListCommand = new Command<DatabaseContext>()
       {
         slug: string;
         created_at: Date;
-        databases: Array<{ name: string; status: string; created_at: Date }>;
+        databases: Array<{
+          name: string;
+          status: string;
+          created_at: Date;
+          metadata?: { td_id?: string };
+        }>;
         assignments: Array<{ app_slug: string }>;
       } & ConnectionInfo
     >;
@@ -344,11 +357,17 @@ const databasesListCommand = new Command<DatabaseContext>()
         createdAt: database.created_at,
         assignments: database.assignments.map((a) => a.app_slug),
         connection: database.safeConnectionConfig,
-        databases: database.databases.map((db) => ({
-          name: db.name,
-          status: db.status,
-          createdAt: db.created_at,
-        })),
+        databases: database.databases.map((db) => {
+          const databaseId = db.metadata?.td_id;
+          return {
+            name: db.name,
+            status: db.status,
+            createdAt: db.created_at,
+            ...(databaseId
+              ? { databaseId, connectUrl: kvConnectUrl(databaseId) }
+              : {}),
+          };
+        }),
       })));
       return;
     }
@@ -371,7 +390,7 @@ const databasesListCommand = new Command<DatabaseContext>()
       },
       (database) => {
         return {
-          headers: ["NAME", "STATUS", "CREATED"],
+          headers: ["NAME", "STATUS", "CREATED", "DATABASE ID"],
           rows: database.databases.map((database) => {
             return [
               database.name,
@@ -379,6 +398,7 @@ const databasesListCommand = new Command<DatabaseContext>()
               renderTemporalTimestamp(
                 database.created_at.toISOString(),
               ),
+              database.metadata?.td_id ?? "",
             ];
           }),
         };

--- a/deploy/database.ts
+++ b/deploy/database.ts
@@ -15,10 +15,6 @@ export type DatabaseContext = GlobalContext & {
   org?: string;
 };
 
-/**
- * Build the Deno KV connect URL for a per-environment database id, suitable for
- * `Deno.openKv("https://api.deno.com/v2/databases/<id>/connect")`.
- */
 function kvConnectUrl(databaseId: string): string {
   return `https://api.deno.com/v2/databases/${databaseId}/connect`;
 }

--- a/deploy/database.ts
+++ b/deploy/database.ts
@@ -80,11 +80,15 @@ const databasesProvisionCommand = new Command<DatabaseContext>()
         },
     });
 
-    console.log(
-      `${
-        green("✔")
-      } Successfully provisioned ${options.kind} database '${name}'.`,
-    );
+    if (options.json) {
+      writeJsonResult({ name, engine: options.kind, org });
+    } else {
+      console.error(
+        `${
+          green("✔")
+        } Successfully provisioned ${options.kind} database '${name}'.`,
+      );
+    }
   }));
 
 const databasesLinkCommand = new Command<DatabaseContext>()
@@ -172,7 +176,11 @@ const databasesLinkCommand = new Command<DatabaseContext>()
         engine,
         connection_config: connectionConfig,
       });
-      console.log(`${green("✔")} Connection test successful.`);
+      if (options.json) {
+        writeJsonResult({ name, engine, dryRun: true, ok: true });
+      } else {
+        console.error(`${green("✔")} Connection test successful.`);
+      }
     } else {
       await trpcClient.mutation("databases.createInstance", {
         org: org,
@@ -180,7 +188,11 @@ const databasesLinkCommand = new Command<DatabaseContext>()
         engine,
         connectionConfig,
       });
-      console.log(`${green("✔")} Successfully linked database '${name}'.`);
+      if (options.json) {
+        writeJsonResult({ name, engine, org });
+      } else {
+        console.error(`${green("✔")} Successfully linked database '${name}'.`);
+      }
     }
   }));
 
@@ -201,9 +213,15 @@ const databasesAssignCommand = new Command<DatabaseContext>()
       databaseInstance: name,
     });
 
-    console.log(
-      `${green("✔")} Successfully assigned database '${name}' to app '${app}'.`,
-    );
+    if (options.json) {
+      writeJsonResult({ database: name, app, org });
+    } else {
+      console.error(
+        `${
+          green("✔")
+        } Successfully assigned database '${name}' to app '${app}'.`,
+      );
+    }
   }));
 
 const databasesDetachCommand = new Command<DatabaseContext>()
@@ -223,11 +241,15 @@ const databasesDetachCommand = new Command<DatabaseContext>()
       databaseInstance: name,
     });
 
-    console.log(
-      `${
-        green("✔")
-      } Successfully detached database '${name}' from app '${app}'.`,
-    );
+    if (options.json) {
+      writeJsonResult({ database: name, app, org });
+    } else {
+      console.error(
+        `${
+          green("✔")
+        } Successfully detached database '${name}' from app '${app}'.`,
+      );
+    }
   }));
 
 const databasesQueryCommand = new Command<DatabaseContext>()
@@ -420,7 +442,11 @@ const databasesDeleteCommand = new Command<DatabaseContext>()
       databaseInstance: name,
     });
 
-    console.log(`${green("✔")} Successfully deleted database '${name}'.`);
+    if (options.json) {
+      writeJsonResult({ name, org });
+    } else {
+      console.error(`${green("✔")} Successfully deleted database '${name}'.`);
+    }
   }));
 
 export const databasesCommand = new Command<GlobalContext>()


### PR DESCRIPTION
## What

Two related improvements to `deploy/database.ts`:

### 1. Expose the Deno KV connect database id (closes #106)

`database list` exposed only the generated `clientId` and dropped the
per-environment Deno KV connect UUID that agents need to build
`Deno.openKv("https://api.deno.com/v2/databases/<id>/connect")`. The backend
already returns it per environment as `databases[].metadata.td_id`.

Now each KV environment in `--json` includes `databaseId` and a derived
`connectUrl`, and the table output gains a `DATABASE ID` column:

```json
{
  "name": "f89123-production",
  "status": "ready",
  "databaseId": "…",
  "connectUrl": "https://api.deno.com/v2/databases/…/connect"
}
```

Verified live: `Deno.openKv` against the produced `connectUrl` (with the org
token as `DENO_KV_ACCESS_TOKEN`) connects and round-trips set/get/delete.

### 2. Mutation `--json` stdout discipline

`provision`/`link`/`assign`/`detach`/`delete` printed human text to **stdout**
and never emitted a JSON result. They now emit a single JSON result via
`writeJsonResult` on stdout under `--json`, and route success/status text to
**stderr** otherwise.

## Note on overlap

Sibling PR #105 (issue #104) also edits the `link` command (option declarations,
`--port` type, payload key). This PR leaves those untouched and only adds the
JSON/stderr branching around `link`'s success messages — should rebase cleanly.