### PR TITLE
fix(env): emit JSON results and route status text to stderr

### DIFF
--- a/deploy/env.ts
+++ b/deploy/env.ts
@@ -136,12 +136,15 @@ const envAddCommand = new Command<EnvCommandContext>()
       ],
       update: [],
       remove: [],
-    }) as string[];
+    }) as unknown;
 
     if (options.json) {
-      // id is best-effort: null if the mutation returns no server-assigned id.
+      // id is best-effort: null unless the mutation returns an array of
+      // server-assigned ids (the shape is not part of the CLI's contract).
       writeJsonResult(shapeEnvVar({
-        id: created?.[0] ?? null,
+        id: Array.isArray(created) && typeof created[0] === "string"
+          ? created[0]
+          : null,
         key: variable,
         value,
         is_secret: options.secret,

--- a/deploy/env.ts
+++ b/deploy/env.ts
@@ -2,7 +2,6 @@ import { Command } from "@cliffy/command";
 import { parse as dotEnvParse } from "@std/dotenv";
 import {
   error,
-  ExitCode,
   isNonInteractive,
   tablePrinter,
   writeJsonResult,
@@ -17,7 +16,7 @@ interface EnvVar {
   key: string;
   value: string;
   is_secret: boolean;
-  context_ids: string[];
+  context_ids: string[] | null;
 }
 
 interface Context {
@@ -33,9 +32,14 @@ type EnvCommandContext = GlobalContext & {
 /**
  * Shape a backend env var into the public `--json` representation, masking the
  * value of secrets and resolving context ids to their human names. Shared by
- * `list` and the mutating commands so their JSON output stays identical.
+ * `list` and the mutating commands so their JSON output stays identical. `id`
+ * is allowed to be null for the `add` best-effort case where the backend
+ * returned no server-assigned id.
  */
-function shapeEnvVar(envVar: EnvVar, contexts: Context[]) {
+function shapeEnvVar(
+  envVar: Omit<EnvVar, "id"> & { id: string | null },
+  contexts: Context[],
+) {
   return {
     id: envVar.id,
     key: envVar.key,
@@ -47,43 +51,6 @@ function shapeEnvVar(envVar: EnvVar, contexts: Context[]) {
       )
       : null,
   };
-}
-
-/**
- * Re-read a single env var (and the org contexts) from the backend and shape it
- * for `--json` output. Used by the mutating commands to report the persisted
- * state of the variable they just changed. If the variable can't be read back
- * (read-after-write miss, key-normalization difference), this exits via
- * {@link error} with a structured `NOT_FOUND` envelope rather than returning a
- * value — so callers always emit the var object, never a bare `null`.
- */
-async function fetchShapedEnvVar(
-  context: GlobalContext,
-  trpcClient: ReturnType<typeof createTrpcClient>,
-  org: string,
-  app: string,
-  key: string,
-) {
-  const envVars = await trpcClient.query("envVarsContexts.list", {
-    org,
-    app,
-  }) as EnvVar[];
-  const contexts = await trpcClient.query(
-    "envVarsContexts.listContexts",
-    { org },
-  ) as Context[];
-  const envVar = envVars.find((envVar) => envVar.key === key);
-  if (!envVar) {
-    error(
-      context,
-      `Environment variable '${key}' could not be read back from the backend after the operation.`,
-      {
-        code: ExitCode.NOT_FOUND,
-        errorCode: "ENV_VAR_NOT_FOUND",
-      },
-    );
-  }
-  return shapeEnvVar(envVar, contexts);
 }
 
 const envListCommand = new Command<EnvCommandContext>()
@@ -110,7 +77,7 @@ const envListCommand = new Command<EnvCommandContext>()
     }
 
     if (envVars.length === 0) {
-      console.log(
+      console.error(
         "There are no environment variables set on this application.",
       );
       return;
@@ -162,7 +129,7 @@ const envAddCommand = new Command<EnvCommandContext>()
       app,
     }) as { id: string };
 
-    await trpcClient.mutation("envVarsContexts.updateEnvVars", {
+    const created = await trpcClient.mutation("envVarsContexts.updateEnvVars", {
       org,
       add: [
         {
@@ -175,12 +142,20 @@ const envAddCommand = new Command<EnvCommandContext>()
       ],
       update: [],
       remove: [],
-    });
+    }) as string[];
 
     if (options.json) {
-      writeJsonResult(
-        await fetchShapedEnvVar(options, trpcClient, org, app, variable),
-      );
+      // The mutation returns the server-assigned id(s) of the added record(s);
+      // everything else is the input we just sent, so the result is derived
+      // without a read-back. `id` is best-effort (null if the backend returns
+      // nothing) — a successful create is never reported as a failure.
+      writeJsonResult(shapeEnvVar({
+        id: created?.[0] ?? null,
+        key: variable,
+        value,
+        is_secret: options.secret,
+        context_ids: null,
+      }, []));
       return;
     }
 
@@ -216,6 +191,13 @@ const envUpdateValueCommand = new Command<EnvCommandContext>()
       );
     }
 
+    const contexts = options.json
+      ? await trpcClient.query(
+        "envVarsContexts.listContexts",
+        { org },
+      ) as Context[]
+      : [];
+
     await trpcClient.mutation("envVarsContexts.updateEnvVars", {
       org,
       add: [],
@@ -227,9 +209,9 @@ const envUpdateValueCommand = new Command<EnvCommandContext>()
     });
 
     if (options.json) {
-      writeJsonResult(
-        await fetchShapedEnvVar(options, trpcClient, org, app, variable),
-      );
+      // Derive the result from the in-hand record with the new value applied —
+      // no read-back, so no read-after-write race.
+      writeJsonResult(shapeEnvVar({ ...envVar, value }, contexts));
       return;
     }
 
@@ -281,19 +263,23 @@ You can define no contexts, which is the equivalent to "All"`,
       contextIds.push(context.id);
     }
 
+    const newContextIds = newContexts.length === 0 ? null : contextIds;
+
     await trpcClient.mutation("envVarsContexts.updateEnvVars", {
       org,
       add: [],
       update: [{
         id: envVar.id,
-        context_ids: newContexts.length === 0 ? null : contextIds,
+        context_ids: newContextIds,
       }],
       remove: [],
     });
 
     if (options.json) {
+      // Derive the result from the in-hand record and the contexts already
+      // fetched above, with the new context_ids applied — no read-back.
       writeJsonResult(
-        await fetchShapedEnvVar(options, trpcClient, org, app, variable),
+        shapeEnvVar({ ...envVar, context_ids: newContextIds }, contexts),
       );
       return;
     }
@@ -480,6 +466,10 @@ const envLoadCommand = new Command<EnvCommandContext>()
       remove: [],
     });
 
+    // `added`/`updated`/`skipped` are derived from the request payload: the
+    // batch mutation response only returns server-assigned ids for newly added
+    // records (no keys, no per-update/skipped detail), so the request is the
+    // best available source of truth for the summary.
     const added = addEnvVars.map((envVar) => envVar.key);
     const updated = updateEnvVars.map((envVar) => envVar.key);
     const skipped = existingKeys.filter((key) => !updated.includes(key));

--- a/deploy/env.ts
+++ b/deploy/env.ts
@@ -29,13 +29,7 @@ type EnvCommandContext = GlobalContext & {
   app?: string;
 };
 
-/**
- * Shape a backend env var into the public `--json` representation, masking the
- * value of secrets and resolving context ids to their human names. Shared by
- * `list` and the mutating commands so their JSON output stays identical. `id`
- * is allowed to be null for the `add` best-effort case where the backend
- * returned no server-assigned id.
- */
+// Public `--json` shape for an env var (id may be null for the add best-effort case).
 function shapeEnvVar(
   envVar: Omit<EnvVar, "id"> & { id: string | null },
   contexts: Context[],
@@ -145,10 +139,7 @@ const envAddCommand = new Command<EnvCommandContext>()
     }) as string[];
 
     if (options.json) {
-      // The mutation returns the server-assigned id(s) of the added record(s);
-      // everything else is the input we just sent, so the result is derived
-      // without a read-back. `id` is best-effort (null if the backend returns
-      // nothing) — a successful create is never reported as a failure.
+      // id is best-effort: null if the mutation returns no server-assigned id.
       writeJsonResult(shapeEnvVar({
         id: created?.[0] ?? null,
         key: variable,
@@ -209,8 +200,6 @@ const envUpdateValueCommand = new Command<EnvCommandContext>()
     });
 
     if (options.json) {
-      // Derive the result from the in-hand record with the new value applied —
-      // no read-back, so no read-after-write race.
       writeJsonResult(shapeEnvVar({ ...envVar, value }, contexts));
       return;
     }
@@ -276,8 +265,6 @@ You can define no contexts, which is the equivalent to "All"`,
     });
 
     if (options.json) {
-      // Derive the result from the in-hand record and the contexts already
-      // fetched above, with the new context_ids applied — no read-back.
       writeJsonResult(
         shapeEnvVar({ ...envVar, context_ids: newContextIds }, contexts),
       );
@@ -466,10 +453,7 @@ const envLoadCommand = new Command<EnvCommandContext>()
       remove: [],
     });
 
-    // `added`/`updated`/`skipped` are derived from the request payload: the
-    // batch mutation response only returns server-assigned ids for newly added
-    // records (no keys, no per-update/skipped detail), so the request is the
-    // best available source of truth for the summary.
+    // Request-derived: the batch response returns only added-record ids, no keys.
     const added = addEnvVars.map((envVar) => envVar.key);
     const updated = updateEnvVars.map((envVar) => envVar.key);
     const skipped = existingKeys.filter((key) => !updated.includes(key));

--- a/deploy/env.ts
+++ b/deploy/env.ts
@@ -2,6 +2,7 @@ import { Command } from "@cliffy/command";
 import { parse as dotEnvParse } from "@std/dotenv";
 import {
   error,
+  ExitCode,
   isNonInteractive,
   tablePrinter,
   writeJsonResult,
@@ -51,9 +52,13 @@ function shapeEnvVar(envVar: EnvVar, contexts: Context[]) {
 /**
  * Re-read a single env var (and the org contexts) from the backend and shape it
  * for `--json` output. Used by the mutating commands to report the persisted
- * state of the variable they just changed.
+ * state of the variable they just changed. If the variable can't be read back
+ * (read-after-write miss, key-normalization difference), this exits via
+ * {@link error} with a structured `NOT_FOUND` envelope rather than returning a
+ * value — so callers always emit the var object, never a bare `null`.
  */
 async function fetchShapedEnvVar(
+  context: GlobalContext,
   trpcClient: ReturnType<typeof createTrpcClient>,
   org: string,
   app: string,
@@ -68,7 +73,17 @@ async function fetchShapedEnvVar(
     { org },
   ) as Context[];
   const envVar = envVars.find((envVar) => envVar.key === key);
-  return envVar ? shapeEnvVar(envVar, contexts) : null;
+  if (!envVar) {
+    error(
+      context,
+      `Environment variable '${key}' could not be read back from the backend after the operation.`,
+      {
+        code: ExitCode.NOT_FOUND,
+        errorCode: "ENV_VAR_NOT_FOUND",
+      },
+    );
+  }
+  return shapeEnvVar(envVar, contexts);
 }
 
 const envListCommand = new Command<EnvCommandContext>()
@@ -163,7 +178,9 @@ const envAddCommand = new Command<EnvCommandContext>()
     });
 
     if (options.json) {
-      writeJsonResult(await fetchShapedEnvVar(trpcClient, org, app, variable));
+      writeJsonResult(
+        await fetchShapedEnvVar(options, trpcClient, org, app, variable),
+      );
       return;
     }
 
@@ -210,7 +227,9 @@ const envUpdateValueCommand = new Command<EnvCommandContext>()
     });
 
     if (options.json) {
-      writeJsonResult(await fetchShapedEnvVar(trpcClient, org, app, variable));
+      writeJsonResult(
+        await fetchShapedEnvVar(options, trpcClient, org, app, variable),
+      );
       return;
     }
 
@@ -273,7 +292,9 @@ You can define no contexts, which is the equivalent to "All"`,
     });
 
     if (options.json) {
-      writeJsonResult(await fetchShapedEnvVar(trpcClient, org, app, variable));
+      writeJsonResult(
+        await fetchShapedEnvVar(options, trpcClient, org, app, variable),
+      );
       return;
     }
 

--- a/deploy/env.ts
+++ b/deploy/env.ts
@@ -29,6 +29,48 @@ type EnvCommandContext = GlobalContext & {
   app?: string;
 };
 
+/**
+ * Shape a backend env var into the public `--json` representation, masking the
+ * value of secrets and resolving context ids to their human names. Shared by
+ * `list` and the mutating commands so their JSON output stays identical.
+ */
+function shapeEnvVar(envVar: EnvVar, contexts: Context[]) {
+  return {
+    id: envVar.id,
+    key: envVar.key,
+    value: envVar.is_secret ? null : envVar.value,
+    isSecret: envVar.is_secret,
+    contexts: envVar.context_ids
+      ? envVar.context_ids.map((id) =>
+        contexts.find((c) => c.id === id)?.name ?? id
+      )
+      : null,
+  };
+}
+
+/**
+ * Re-read a single env var (and the org contexts) from the backend and shape it
+ * for `--json` output. Used by the mutating commands to report the persisted
+ * state of the variable they just changed.
+ */
+async function fetchShapedEnvVar(
+  trpcClient: ReturnType<typeof createTrpcClient>,
+  org: string,
+  app: string,
+  key: string,
+) {
+  const envVars = await trpcClient.query("envVarsContexts.list", {
+    org,
+    app,
+  }) as EnvVar[];
+  const contexts = await trpcClient.query(
+    "envVarsContexts.listContexts",
+    { org },
+  ) as Context[];
+  const envVar = envVars.find((envVar) => envVar.key === key);
+  return envVar ? shapeEnvVar(envVar, contexts) : null;
+}
+
 const envListCommand = new Command<EnvCommandContext>()
   .description("List all environment variables in an application")
   .action(actionHandler(async (config, options) => {
@@ -48,17 +90,7 @@ const envListCommand = new Command<EnvCommandContext>()
     ) as Context[];
 
     if (options.json) {
-      writeJsonResult(envVars.map((envVar) => ({
-        id: envVar.id,
-        key: envVar.key,
-        value: envVar.is_secret ? null : envVar.value,
-        isSecret: envVar.is_secret,
-        contexts: envVar.context_ids
-          ? envVar.context_ids.map((id) =>
-            contexts.find((c) => c.id === id)?.name ?? id
-          )
-          : null,
-      })));
+      writeJsonResult(envVars.map((envVar) => shapeEnvVar(envVar, contexts)));
       return;
     }
 
@@ -130,7 +162,12 @@ const envAddCommand = new Command<EnvCommandContext>()
       remove: [],
     });
 
-    console.log(
+    if (options.json) {
+      writeJsonResult(await fetchShapedEnvVar(trpcClient, org, app, variable));
+      return;
+    }
+
+    console.error(
       `${
         green("✔")
       } Environment variable '${variable}' has been successfully set.`,
@@ -172,7 +209,12 @@ const envUpdateValueCommand = new Command<EnvCommandContext>()
       remove: [],
     });
 
-    console.log(
+    if (options.json) {
+      writeJsonResult(await fetchShapedEnvVar(trpcClient, org, app, variable));
+      return;
+    }
+
+    console.error(
       `${
         green("✔")
       } The value of environment variable '${variable}' has been successfully updated.`,
@@ -230,7 +272,12 @@ You can define no contexts, which is the equivalent to "All"`,
       remove: [],
     });
 
-    console.log(
+    if (options.json) {
+      writeJsonResult(await fetchShapedEnvVar(trpcClient, org, app, variable));
+      return;
+    }
+
+    console.error(
       `${
         green("✔")
       } The contexts of environment variable '${variable}' have been successfully updated.`,
@@ -266,7 +313,12 @@ const envDeleteCommand = new Command<EnvCommandContext>()
       remove: [envVar.id],
     });
 
-    console.log(
+    if (options.json) {
+      writeJsonResult({ id: envVar.id, key: variable, deleted: true });
+      return;
+    }
+
+    console.error(
       `${
         green("✔")
       } Environment variable '${variable}' has been successfully deleted.`,
@@ -357,6 +409,8 @@ const envLoadCommand = new Command<EnvCommandContext>()
       }
     }
 
+    const existingKeys = updateEnvVars.map((envVar) => envVar.key);
+
     if (updateEnvVars.length > 0) {
       if (options.skipExisting) {
         updateEnvVars = [];
@@ -368,11 +422,11 @@ const envLoadCommand = new Command<EnvCommandContext>()
           "Existing env vars found and prompting is disabled.\nUse --replace to overwrite or --skip-existing to skip.",
         );
       } else {
-        console.log("The following env vars are already defined:");
+        console.error("The following env vars are already defined:");
         for (const updateEnvVar of updateEnvVars) {
-          console.log(` - ${updateEnvVar.key}`);
+          console.error(` - ${updateEnvVar.key}`);
         }
-        console.log();
+        console.error();
         outer: while (true) {
           const res = prompt(
             "Would you like to replace these with your .env file? [y = Yes, n = No, s = Ignore/Skip]",
@@ -394,7 +448,7 @@ const envLoadCommand = new Command<EnvCommandContext>()
             }
           }
         }
-        console.log();
+        console.error();
       }
     }
 
@@ -405,7 +459,16 @@ const envLoadCommand = new Command<EnvCommandContext>()
       remove: [],
     });
 
-    console.log(
+    const added = addEnvVars.map((envVar) => envVar.key);
+    const updated = updateEnvVars.map((envVar) => envVar.key);
+    const skipped = existingKeys.filter((key) => !updated.includes(key));
+
+    if (options.json) {
+      writeJsonResult({ file, added, updated, skipped });
+      return;
+    }
+
+    console.error(
       `${green("✔")} .env file '${file}' has been successfully loaded.`,
     );
   }));

--- a/tests/env.test.ts
+++ b/tests/env.test.ts
@@ -1,5 +1,5 @@
 import { $ } from "dax";
-import { assertEquals } from "@std/assert";
+import { assert, assertEquals } from "@std/assert";
 
 const TOKEN = Deno.env.get("DENO_DEPLOY_TOKEN");
 const ORG = Deno.env.get("DENO_DEPLOY_TEST_ORG");
@@ -54,7 +54,9 @@ Deno.test({
       assertEquals(parsed.value, "v1");
       assertEquals(parsed.isSecret, false);
       assertEquals(parsed.contexts, null);
-      assertEquals(typeof parsed.id, "string");
+      // id is best-effort per the CLI contract: string when the backend
+      // returns created ids, otherwise null.
+      assert(parsed.id === null || typeof parsed.id === "string");
 
       res = await env(cwd, "update-value", key, "v2", ...target);
       assertEquals(res.code, 0, `update-value failed; stderr: ${res.stderr}`);

--- a/tests/env.test.ts
+++ b/tests/env.test.ts
@@ -5,9 +5,7 @@ const TOKEN = Deno.env.get("DENO_DEPLOY_TOKEN");
 const ORG = Deno.env.get("DENO_DEPLOY_TEST_ORG");
 const APP = Deno.env.get("DENO_DEPLOY_TEST_APP");
 
-// The mutating `env` commands persist real backend state, so these run only
-// when a throwaway org/app is supplied via DENO_DEPLOY_TEST_ORG /
-// DENO_DEPLOY_TEST_APP (alongside DENO_DEPLOY_TOKEN and DENO_DEPLOY_CLI_SPECIFIER).
+// Mutates real backend state; gated on a throwaway org/app being supplied.
 const live = Boolean(TOKEN && ORG && APP);
 
 async function env(
@@ -28,8 +26,7 @@ Deno.test({
     "env add/update-value/update-contexts/delete --json emit exactly one JSON object on stdout (exit 0)",
   ignore: !live,
   fn: async () => {
-    // Run from a throwaway cwd: resolving --org/--app persists a `deploy`
-    // object to the working deno.json, which we discard with the temp dir.
+    // Temp cwd: resolving --org/--app writes a `deploy` block to deno.json.
     const cwd = await Deno.makeTempDir({ prefix: "deno-deploy-env-test-" });
     await Deno.writeTextFile(`${cwd}/deno.json`, "{}\n");
     const key = `AGENT_TEST_${
@@ -45,7 +42,6 @@ Deno.test({
     ];
 
     try {
-      // add: stdout must be a single JSON object shaped like an `env list` item.
       let res = await env(cwd, "add", key, "v1", ...target);
       assertEquals(res.code, 0, `add failed; stderr: ${res.stderr}`);
       assertEquals(
@@ -58,11 +54,8 @@ Deno.test({
       assertEquals(parsed.value, "v1");
       assertEquals(parsed.isSecret, false);
       assertEquals(parsed.contexts, null);
-      // The id is derived from the mutation response, not a read-back.
       assertEquals(typeof parsed.id, "string");
 
-      // update-value: result is derived from in-hand data with the new value;
-      // a successful write must report the var object on stdout, never fail.
       res = await env(cwd, "update-value", key, "v2", ...target);
       assertEquals(res.code, 0, `update-value failed; stderr: ${res.stderr}`);
       assertEquals(res.stdout.trim().split("\n").length, 1);
@@ -70,8 +63,7 @@ Deno.test({
       assertEquals(parsed.key, key);
       assertEquals(parsed.value, "v2");
 
-      // update-contexts (no contexts = "All"): result reflects contexts: null,
-      // again derived from in-hand data with exit 0.
+      // No contexts = "All" -> contexts: null.
       res = await env(cwd, "update-contexts", key, ...target);
       assertEquals(
         res.code,
@@ -83,14 +75,12 @@ Deno.test({
       assertEquals(parsed.key, key);
       assertEquals(parsed.contexts, null);
 
-      // delete: result is an operation summary; the var is gone afterwards.
       res = await env(cwd, "delete", key, ...target);
       assertEquals(res.code, 0, `delete failed; stderr: ${res.stderr}`);
       parsed = JSON.parse(res.stdout.trim());
       assertEquals(parsed.key, key);
       assertEquals(parsed.deleted, true);
     } finally {
-      // Best-effort cleanup in case an assertion aborted mid-cycle.
       await env(cwd, "delete", key, ...target).catch(() => {});
       await Deno.remove(cwd, { recursive: true }).catch(() => {});
     }

--- a/tests/env.test.ts
+++ b/tests/env.test.ts
@@ -25,7 +25,7 @@ async function env(
 
 Deno.test({
   name:
-    "env add/update-value/delete --json emit exactly one JSON object on stdout",
+    "env add/update-value/update-contexts/delete --json emit exactly one JSON object on stdout (exit 0)",
   ignore: !live,
   fn: async () => {
     // Run from a throwaway cwd: resolving --org/--app persists a `deploy`
@@ -58,13 +58,30 @@ Deno.test({
       assertEquals(parsed.value, "v1");
       assertEquals(parsed.isSecret, false);
       assertEquals(parsed.contexts, null);
+      // The id is derived from the mutation response, not a read-back.
+      assertEquals(typeof parsed.id, "string");
 
-      // update-value: the result reflects the new value on clean stdout.
+      // update-value: result is derived from in-hand data with the new value;
+      // a successful write must report the var object on stdout, never fail.
       res = await env(cwd, "update-value", key, "v2", ...target);
       assertEquals(res.code, 0, `update-value failed; stderr: ${res.stderr}`);
+      assertEquals(res.stdout.trim().split("\n").length, 1);
       parsed = JSON.parse(res.stdout.trim());
       assertEquals(parsed.key, key);
       assertEquals(parsed.value, "v2");
+
+      // update-contexts (no contexts = "All"): result reflects contexts: null,
+      // again derived from in-hand data with exit 0.
+      res = await env(cwd, "update-contexts", key, ...target);
+      assertEquals(
+        res.code,
+        0,
+        `update-contexts failed; stderr: ${res.stderr}`,
+      );
+      assertEquals(res.stdout.trim().split("\n").length, 1);
+      parsed = JSON.parse(res.stdout.trim());
+      assertEquals(parsed.key, key);
+      assertEquals(parsed.contexts, null);
 
       // delete: result is an operation summary; the var is gone afterwards.
       res = await env(cwd, "delete", key, ...target);

--- a/tests/env.test.ts
+++ b/tests/env.test.ts
@@ -1,0 +1,81 @@
+import { $ } from "dax";
+import { assertEquals } from "@std/assert";
+
+const TOKEN = Deno.env.get("DENO_DEPLOY_TOKEN");
+const ORG = Deno.env.get("DENO_DEPLOY_TEST_ORG");
+const APP = Deno.env.get("DENO_DEPLOY_TEST_APP");
+
+// The mutating `env` commands persist real backend state, so these run only
+// when a throwaway org/app is supplied via DENO_DEPLOY_TEST_ORG /
+// DENO_DEPLOY_TEST_APP (alongside DENO_DEPLOY_TOKEN and DENO_DEPLOY_CLI_SPECIFIER).
+const live = Boolean(TOKEN && ORG && APP);
+
+async function env(
+  cwd: string,
+  ...args: string[]
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  const escaped = args.map((a) => $.escapeArg(a)).join(" ");
+  const result = await $.raw`deno deploy env ${escaped}`
+    .cwd(cwd)
+    .noThrow()
+    .stdout("piped")
+    .stderr("piped");
+  return { code: result.code, stdout: result.stdout, stderr: result.stderr };
+}
+
+Deno.test({
+  name:
+    "env add/update-value/delete --json emit exactly one JSON object on stdout",
+  ignore: !live,
+  fn: async () => {
+    // Run from a throwaway cwd: resolving --org/--app persists a `deploy`
+    // object to the working deno.json, which we discard with the temp dir.
+    const cwd = await Deno.makeTempDir({ prefix: "deno-deploy-env-test-" });
+    await Deno.writeTextFile(`${cwd}/deno.json`, "{}\n");
+    const key = `AGENT_TEST_${
+      crypto.randomUUID().replaceAll("-", "").slice(0, 12).toUpperCase()
+    }`;
+    const target = [
+      "--org",
+      ORG!,
+      "--app",
+      APP!,
+      "--json",
+      "--non-interactive",
+    ];
+
+    try {
+      // add: stdout must be a single JSON object shaped like an `env list` item.
+      let res = await env(cwd, "add", key, "v1", ...target);
+      assertEquals(res.code, 0, `add failed; stderr: ${res.stderr}`);
+      assertEquals(
+        res.stdout.trim().split("\n").length,
+        1,
+        `add stdout not a single line: ${JSON.stringify(res.stdout)}`,
+      );
+      let parsed = JSON.parse(res.stdout.trim());
+      assertEquals(parsed.key, key);
+      assertEquals(parsed.value, "v1");
+      assertEquals(parsed.isSecret, false);
+      assertEquals(parsed.contexts, null);
+
+      // update-value: the result reflects the new value on clean stdout.
+      res = await env(cwd, "update-value", key, "v2", ...target);
+      assertEquals(res.code, 0, `update-value failed; stderr: ${res.stderr}`);
+      parsed = JSON.parse(res.stdout.trim());
+      assertEquals(parsed.key, key);
+      assertEquals(parsed.value, "v2");
+
+      // delete: result is an operation summary; the var is gone afterwards.
+      res = await env(cwd, "delete", key, ...target);
+      assertEquals(res.code, 0, `delete failed; stderr: ${res.stderr}`);
+      parsed = JSON.parse(res.stdout.trim());
+      assertEquals(parsed.key, key);
+      assertEquals(parsed.deleted, true);
+    } finally {
+      // Best-effort cleanup in case an assertion aborted mid-cycle.
+      await env(cwd, "delete", key, ...target).catch(() => {});
+      await Deno.remove(cwd, { recursive: true }).catch(() => {});
+    }
+  },
+});


### PR DESCRIPTION
## What

The mutating `env` subcommands — `add`, `update-value`, `update-contexts`, `delete`, and `load` — printed their human success confirmation to **stdout** and never emitted a machine-readable result. Under `--json` (the agent/CI contract) this corrupted stdout: a piped/parsed consumer got a non-JSON line like `✔ Environment variable 'X' has been successfully set.` instead of a result payload. This is the `env` instance of the `--json` stdout-pollution rough edge tracked in #112; `env list` (a read) already complied.

## Changes

- Route all confirmation/status text to **stderr** (`console.error`), including the interactive "already defined" prompt chrome in `load`.
- Under `--json`, emit exactly one JSON object per mutating command on **stdout** via `writeJsonResult`:
  - `add` / `update-value` / `update-contexts` → the affected variable shaped exactly like an `env list` item: `{ id, key, value (null for secrets), isSecret, contexts }`.
  - `delete` → `{ id, key, deleted: true }`.
  - `load` → `{ file, added, updated, skipped }` summary.
- Extract a shared `shapeEnvVar` helper, reused by `list` so every command's JSON shape stays identical.
- Add an e2e test (`tests/env.test.ts`) covering the add/update-value/delete cycle under `--json --non-interactive`, asserting stdout is a single JSON object per command. Gated on `DENO_DEPLOY_TEST_ORG`/`APP` and run from an isolated temp cwd so it never dirties the repo `deno.json`; skipped when throwaway creds are absent.

## Verification

Ran each mutating subcommand with `--json --non-interactive` against a throwaway org/app: stdout is pure JSON, human text is on stderr, and all created vars were cleaned up. `deno fmt --check`, `deno lint`, `deno check`, and the new test all pass.