### PR TITLE
feat(logs): add --once for bounded non-interactive capture

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -199,7 +199,11 @@ export function actionHandler<
           }
           this.configSaved = true;
 
-          if (this.doNotCreate && !config) {
+          // `config` is always a truthy wrapper object; `config.config` is the
+          // existing config file (if any). When a command opted out of file
+          // creation, skip writing only when there is no file to update — i.e.
+          // never create a new deno.jsonc as a side effect.
+          if (this.doNotCreate && !config.config) {
             return Promise.resolve();
           }
 

--- a/config.ts
+++ b/config.ts
@@ -199,10 +199,8 @@ export function actionHandler<
           }
           this.configSaved = true;
 
-          // `config` is always a truthy wrapper object; `config.config` is the
-          // existing config file (if any). When a command opted out of file
-          // creation, skip writing only when there is no file to update — i.e.
-          // never create a new deno.jsonc as a side effect.
+          // Skip writing only with no existing file to update (`config` is the
+          // always-truthy wrapper; `config.config` is the file, if any).
           if (this.doNotCreate && !config.config) {
             return Promise.resolve();
           }

--- a/deploy/mod.ts
+++ b/deploy/mod.ts
@@ -142,9 +142,7 @@ const logsCommand = new Command<GlobalContext>()
     "logs --app my-app --once --json --non-interactive",
   )
   .action(actionHandler(async (config, options) => {
-    // `logs` is read-only: like the other inspection commands it must not
-    // create a deno.jsonc as a side effect (which would also print a non-JSON
-    // "Created configuration file" line on stdout, breaking --json output).
+    // Read-only: don't create a deno.jsonc (its stdout notice breaks --json).
     config.noCreate();
     const org = await getOrg(options, config, options.org);
     const { app } = await getApp(options, config, false, org, options.app);
@@ -167,11 +165,8 @@ const logsCommand = new Command<GlobalContext>()
     const seenIds = new Set();
     let onceConnected = false;
 
-    // In --once mode we drain the backfill window and exit at the live boundary
-    // instead of tailing forever. Default that window to the last hour when no
-    // explicit --start is given, so the bounded capture actually has logs to
-    // drain — a bare `new Date()` would request an empty window. An explicit
-    // --start always wins.
+    // --once without --start defaults to the last hour (a `new Date()` start
+    // would request an empty window with nothing to drain).
     const ONCE_LOOKBACK_MS = 60 * 60 * 1000;
     const startDate = options.start
       ? new Date(options.start)
@@ -193,10 +188,7 @@ const logsCommand = new Command<GlobalContext>()
         onData: (data: unknown) => {
           const typedData = data as "streaming" | null | LogEntry[];
           if (typedData === "streaming") {
-            // Backfill complete: the server is about to switch to live tailing.
-            // In --once mode this boundary is our cue to stop — all currently
-            // available logs have already been flushed synchronously above, so
-            // close the subscription and exit cleanly.
+            // End of backfill: in --once mode, stop before live tailing.
             if (options.once) {
               sub.unsubscribe();
               Deno.exit(ExitCode.OK);
@@ -259,8 +251,7 @@ const logsCommand = new Command<GlobalContext>()
         },
         onStopped: () => {
           sub.unsubscribe();
-          // A server-completed stream (e.g. a bounded --start/--end window)
-          // in --once mode is a clean, deterministic end-of-capture.
+          // Server-completed stream (e.g. a bounded --start/--end window).
           if (options.once) {
             Deno.exit(ExitCode.OK);
           }

--- a/deploy/mod.ts
+++ b/deploy/mod.ts
@@ -2,6 +2,7 @@ import { Command, ValidationError } from "@cliffy/command";
 import { green, red, setColorEnabled, yellow } from "@std/fmt/colors";
 import {
   error,
+  ExitCode,
   renderTemporalTimestamp,
   tablePrinter,
   writeJsonResult,
@@ -124,6 +125,10 @@ const logsCommand = new Command<GlobalContext>()
   .option("--end <date:string>", "The ending timestamp of the logs", {
     depends: ["start"],
   })
+  .option(
+    "--once",
+    "Capture currently-available (backfilled) logs, then exit instead of tailing live. Bounded, non-interactive capture for CI/agents; defaults to the last hour, widen with --start.",
+  )
   .example(
     "Stream live logs",
     "logs --app my-app",
@@ -132,7 +137,15 @@ const logsCommand = new Command<GlobalContext>()
     "View logs from a specific time",
     "logs --app my-app --start '2025-01-01T00:00:00Z'",
   )
+  .example(
+    "Capture current logs then exit (CI/agents)",
+    "logs --app my-app --once --json --non-interactive",
+  )
   .action(actionHandler(async (config, options) => {
+    // `logs` is read-only: like the other inspection commands it must not
+    // create a deno.jsonc as a side effect (which would also print a non-JSON
+    // "Created configuration file" line on stdout, breaking --json output).
+    config.noCreate();
     const org = await getOrg(options, config, options.org);
     const { app } = await getApp(options, config, false, org, options.app);
 
@@ -154,14 +167,25 @@ const logsCommand = new Command<GlobalContext>()
     const seenIds = new Set();
     let onceConnected = false;
 
+    // In --once mode we drain the backfill window and exit at the live boundary
+    // instead of tailing forever. Default that window to the last hour when no
+    // explicit --start is given, so the bounded capture actually has logs to
+    // drain — a bare `new Date()` would request an empty window. An explicit
+    // --start always wins.
+    const ONCE_LOOKBACK_MS = 60 * 60 * 1000;
+    const startDate = options.start
+      ? new Date(options.start)
+      : options.once
+      ? new Date(Date.now() - ONCE_LOOKBACK_MS)
+      : new Date();
+
     const encoder = new TextEncoder();
     const sub = trpcClient.subscription(
       "apps.logs",
       {
         org,
         app,
-        start: (options.start ? new Date(options.start) : new Date())
-          .toISOString(),
+        start: startDate.toISOString(),
         end: options.end ? new Date(options.end).toISOString() : undefined,
         filter: {},
       },
@@ -169,6 +193,14 @@ const logsCommand = new Command<GlobalContext>()
         onData: (data: unknown) => {
           const typedData = data as "streaming" | null | LogEntry[];
           if (typedData === "streaming") {
+            // Backfill complete: the server is about to switch to live tailing.
+            // In --once mode this boundary is our cue to stop — all currently
+            // available logs have already been flushed synchronously above, so
+            // close the subscription and exit cleanly.
+            if (options.once) {
+              sub.unsubscribe();
+              Deno.exit(ExitCode.OK);
+            }
             if (!onceConnected && !options.quiet && !options.json) {
               console.log("connected, streaming logs...");
             }
@@ -227,6 +259,11 @@ const logsCommand = new Command<GlobalContext>()
         },
         onStopped: () => {
           sub.unsubscribe();
+          // A server-completed stream (e.g. a bounded --start/--end window)
+          // in --once mode is a clean, deterministic end-of-capture.
+          if (options.once) {
+            Deno.exit(ExitCode.OK);
+          }
         },
       },
     );


### PR DESCRIPTION
## What

Adds `--once` to `deno deploy logs`: a bounded, non-interactive "capture
currently-available logs then exit" mode for CI and agents. Addresses the rough
edge from #112 — previously `logs` could only tail live forever or stream a
fixed `--start`/`--end` window, with no way to grab the current backlog and exit
without already knowing an `--end`.

## Semantics

- `--once` streams the backfilled logs in the window, then exits `0` the moment
  the backend emits its `"streaming"` phase marker (verified empirically: the
  marker is sent *after* the backfill batches, signalling the switch from
  historical backfill to live tailing). It does not enter live tail.
- The SSE subscription is closed (`sub.unsubscribe()`) and the process exits
  cleanly with `ExitCode.OK`. A server-completed stream (`onStopped`, e.g. a
  bounded `--start/--end` window) is also treated as a clean end-of-capture.
- Window defaults to the **last hour** when no `--start` is given (a bare
  `new Date()` start would request an empty window); an explicit `--start`
  widens/narrows it.
- `--json` NDJSON discipline is preserved: only log records on stdout, one JSON
  object per line. An empty window exits `0` with no output.

## Rejected / deferred alternatives

- **Inactivity `--timeout <duration>`** (exit after N seconds of silence): useful
  for bounded *live* capture, but heuristic and non-deterministic. `--once` uses
  a real backend signal (backfill-complete), so it's exact. Can be added later as
  a complementary flag.
- **`--max <n>` lines**: orthogonal cap; not needed for the "drain current
  backlog" use case and easily composed downstream (`| head -n`).

## Supporting fix

`logs` is read-only, so it now calls `config.noCreate()` like the other
inspection commands (`apps`, `orgs`, `deployments`, `whoami`). That exposed a
long-standing bug: the `actionHandler` save guard tested `!config` (the
always-truthy `Config` wrapper) instead of `!config.config` (no existing config
*file*), so `noCreate()` never actually prevented file creation. Fixed. Net
effect: no command creates a stray `deno.jsonc` as a side effect — which in
`--json` mode would otherwise print a non-JSON `Created configuration file` line
on stdout. Existing config files are still updated.

## Verification (live, against a throwaway app)

- `logs --once --json --non-interactive`: exits on its own (~0s), emits clean
  NDJSON (all lines parse), no `deno.jsonc` created.
- Empty window (`--once --start <now>`): exits `0` with no output.
- Human mode (`--once`): exits `0`, formatted output.
- Regression: a pre-existing `deno.json` is still updated with the `deploy`
  object.

## Overlap

Touches the `logs` command region of `deploy/mod.ts`; the `tc/app-production-url`
sibling PR touches the publish/deploy flow in the same file and will rebase.