### PR TITLE
feat: expose app production URL (apps get) + fix apps list org bug

### DIFF
--- a/deploy/apps.ts
+++ b/deploy/apps.ts
@@ -4,6 +4,7 @@ import { actionHandler, getApp, getOrg } from "../config.ts";
 import type { GlobalContext } from "../main.ts";
 import {
   renderTemporalTimestamp,
+  selectProductionUrl,
   tablePrinter,
   writeJsonResult,
 } from "../util.ts";
@@ -85,14 +86,6 @@ const appsListCommand = new Command<GlobalContext>()
     }
   }));
 
-/** Pick the timeline that serves the app's production context. */
-function findProductionTimeline(
-  timelines: TimelineEntry[],
-): TimelineEntry | undefined {
-  return timelines.find((t) => t.context_name === "Production") ??
-    timelines.find((t) => t.partition_config_name === "Production");
-}
-
 const appsGetCommand = new Command<GlobalContext>()
   .description("Show an application, including its production URL and domains")
   .option("--org <name:string>", "The name of the organization")
@@ -127,9 +120,8 @@ const appsGetCommand = new Command<GlobalContext>()
       }) as TimelineEntry[];
     }
 
-    const production = findProductionTimeline(timelines);
-    const domains = (production?.domains ?? []).map((d) => `https://${d}`);
-    const productionUrl = domains[0] ?? null;
+    const { timeline: production, domains, productionUrl } =
+      selectProductionUrl(timelines);
 
     if (options.json) {
       writeJsonResult({

--- a/deploy/apps.ts
+++ b/deploy/apps.ts
@@ -63,7 +63,7 @@ const appsListCommand = new Command<GlobalContext>()
     }
 
     if (res.items.length === 0) {
-      console.log("No applications in this organization.");
+      console.error("No applications in this organization.");
       return;
     }
 
@@ -79,7 +79,9 @@ const appsListCommand = new Command<GlobalContext>()
     );
 
     if (res.nextCursor) {
-      console.log(`\nMore results available; pass --cursor ${res.nextCursor}`);
+      console.error(
+        `\nMore results available; pass --cursor ${res.nextCursor}`,
+      );
     }
   }));
 

--- a/deploy/apps.ts
+++ b/deploy/apps.ts
@@ -1,6 +1,6 @@
 import { Command } from "@cliffy/command";
 import { createTrpcClient } from "../auth.ts";
-import { actionHandler, getOrg } from "../config.ts";
+import { actionHandler, getApp, getOrg } from "../config.ts";
 import type { GlobalContext } from "../main.ts";
 import {
   renderTemporalTimestamp,
@@ -14,6 +14,21 @@ interface AppItem {
   created_at: Date;
   updated_at: Date;
   layers: Array<{ slug: string }>;
+}
+
+interface AppDetail {
+  id: string;
+  slug: string;
+  created_at: Date;
+  updated_at: Date;
+  build_config: { frameworkPreset?: string | null } | null;
+}
+
+interface TimelineEntry {
+  partition_config_name: string;
+  context_name: string;
+  active_revision_id: string | null;
+  domains: string[];
 }
 
 const appsListCommand = new Command<GlobalContext>()
@@ -68,10 +83,95 @@ const appsListCommand = new Command<GlobalContext>()
     }
   }));
 
+/** Pick the timeline that serves the app's production context. */
+function findProductionTimeline(
+  timelines: TimelineEntry[],
+): TimelineEntry | undefined {
+  return timelines.find((t) => t.context_name === "Production") ??
+    timelines.find((t) => t.partition_config_name === "Production");
+}
+
+const appsGetCommand = new Command<GlobalContext>()
+  .description("Show an application, including its production URL and domains")
+  .option("--org <name:string>", "The name of the organization")
+  .option("--app <name:string>", "The name of the application")
+  .action(actionHandler(async (config, options) => {
+    config.noCreate();
+    const org = await getOrg(options, config, options.org);
+    const { app } = await getApp(options, config, false, org, options.app);
+    const trpcClient = createTrpcClient(options);
+
+    const detail = await trpcClient.query("apps.get", {
+      org,
+      app,
+    }) as AppDetail;
+
+    // Domains live on revision timelines, not on the app record. Querying the
+    // timelines of any revision returns the app-wide partition state, so the
+    // latest revision is enough to read the current production domains.
+    const revisions = await trpcClient.query("revisions.listByPage", {
+      org,
+      app,
+      limit: 1,
+    }) as { items: Array<{ id: string }> };
+
+    let timelines: TimelineEntry[] = [];
+    const latestRevision = revisions.items[0]?.id;
+    if (latestRevision) {
+      timelines = await trpcClient.query("revisions.listTimelines", {
+        org,
+        app,
+        revision: latestRevision,
+      }) as TimelineEntry[];
+    }
+
+    const production = findProductionTimeline(timelines);
+    const domains = (production?.domains ?? []).map((d) => `https://${d}`);
+    const productionUrl = domains[0] ?? null;
+
+    if (options.json) {
+      writeJsonResult({
+        id: detail.id,
+        slug: detail.slug,
+        org,
+        productionUrl,
+        domains,
+        productionRevisionId: production?.active_revision_id ?? null,
+        frameworkPreset: detail.build_config?.frameworkPreset ?? null,
+        createdAt: detail.created_at,
+        updatedAt: detail.updated_at,
+        timelines: timelines.map((t) => ({
+          partition: t.partition_config_name,
+          context: t.context_name,
+          activeRevisionId: t.active_revision_id,
+          domains: t.domains.map((d) => `https://${d}`),
+        })),
+      });
+      return;
+    }
+
+    console.log(`App:            ${detail.slug}`);
+    console.log(`Production URL: ${productionUrl ?? "—"}`);
+
+    if (timelines.length > 0) {
+      console.log();
+      tablePrinter(
+        ["PARTITION", "CONTEXT", "DOMAINS"],
+        timelines,
+        (t) => [
+          t.partition_config_name,
+          t.context_name,
+          t.domains.map((d) => `https://${d}`).join(", ") || "—",
+        ],
+      );
+    }
+  }));
+
 export const appsCommand = new Command<GlobalContext>()
   .description("Manage applications")
   .action(() => {
     appsCommand.showHelp();
   })
   .command("list", appsListCommand)
-  .alias("ls");
+  .alias("ls")
+  .command("get", appsGetCommand);

--- a/deploy/apps.ts
+++ b/deploy/apps.ts
@@ -96,10 +96,7 @@ const appsGetCommand = new Command<GlobalContext>()
     const { app } = await getApp(options, config, false, org, options.app);
     const trpcClient = createTrpcClient(options);
 
-    // Domains live on revision timelines, not on the app record. Querying the
-    // timelines of any revision returns the app-wide partition state, so the
-    // latest revision is enough to read the current production domains. Both
-    // queries only depend on org/app, so run them concurrently.
+    // Domains live on revision timelines, not the app record.
     const [detail, revisions] = await Promise.all([
       trpcClient.query("apps.get", { org, app }) as Promise<AppDetail>,
       trpcClient.query("revisions.listByPage", {

--- a/deploy/apps.ts
+++ b/deploy/apps.ts
@@ -27,6 +27,7 @@ const appsListCommand = new Command<GlobalContext>()
     const trpcClient = createTrpcClient(options);
 
     const res = await trpcClient.query("apps.listByPage", {
+      org,
       cursor: options.cursor,
       limit: options.limit ?? 20,
     }) as { items: AppItem[]; nextCursor: string | null };

--- a/deploy/apps.ts
+++ b/deploy/apps.ts
@@ -96,19 +96,18 @@ const appsGetCommand = new Command<GlobalContext>()
     const { app } = await getApp(options, config, false, org, options.app);
     const trpcClient = createTrpcClient(options);
 
-    const detail = await trpcClient.query("apps.get", {
-      org,
-      app,
-    }) as AppDetail;
-
     // Domains live on revision timelines, not on the app record. Querying the
     // timelines of any revision returns the app-wide partition state, so the
-    // latest revision is enough to read the current production domains.
-    const revisions = await trpcClient.query("revisions.listByPage", {
-      org,
-      app,
-      limit: 1,
-    }) as { items: Array<{ id: string }> };
+    // latest revision is enough to read the current production domains. Both
+    // queries only depend on org/app, so run them concurrently.
+    const [detail, revisions] = await Promise.all([
+      trpcClient.query("apps.get", { org, app }) as Promise<AppDetail>,
+      trpcClient.query("revisions.listByPage", {
+        org,
+        app,
+        limit: 1,
+      }) as Promise<{ items: Array<{ id: string }> }>,
+    ]);
 
     let timelines: TimelineEntry[] = [];
     const latestRevision = revisions.items[0]?.id;

--- a/deploy/publish.ts
+++ b/deploy/publish.ts
@@ -38,8 +38,6 @@ export async function publish(
   const quiet = context.quiet || context.json;
   const log: typeof console.log = quiet
     ? () => {}
-    // Status/progress chrome goes to stderr; stdout is reserved for the
-    // (--json) result payload.
     // deno-lint-ignore no-explicit-any
     : console.error.bind(console) as any;
 
@@ -169,9 +167,8 @@ export async function publish(
     }
 
     const useProgress = shouldUseSpinner(context);
-    // Only instantiate the bar when it will actually be drawn; otherwise its
-    // internal render timer keeps the event loop alive and the process hangs
-    // after we're done (e.g. under --json / --no-wait).
+    // Only instantiate when drawn; its render timer otherwise keeps the event
+    // loop alive and hangs the process.
     const progress = useProgress
       ? new ProgressBar({
         max: missingHashes.length,
@@ -270,8 +267,7 @@ export async function publish(
   if (wait) {
     await waitForRevision(context, org, app, revisionId, revision);
   } else if (context.json) {
-    // Without --wait the build hasn't finished, so the production URL isn't
-    // known yet; still emit the revision id so agents can poll/track it.
+    // Build isn't finished yet; emit the revision id so agents can track it.
     writeJsonResult({
       org,
       app,
@@ -297,8 +293,6 @@ export async function waitForRevision(
   const quiet = context.quiet || context.json;
   const log: typeof console.log = quiet
     ? () => {}
-    // Status/progress chrome goes to stderr; stdout is reserved for the
-    // (--json) result payload.
     // deno-lint-ignore no-explicit-any
     : console.error.bind(console) as any;
   const trpcClient = createTrpcClient(context);

--- a/deploy/publish.ts
+++ b/deploy/publish.ts
@@ -33,8 +33,10 @@ export async function publish(
   const quiet = context.quiet || context.json;
   const log: typeof console.log = quiet
     ? () => {}
+    // Status/progress chrome goes to stderr; stdout is reserved for the
+    // (--json) result payload.
     // deno-lint-ignore no-explicit-any
-    : console.log.bind(console) as any;
+    : console.error.bind(console) as any;
 
   function startSpinner(message: string): Spinner {
     const spinner = new Spinner({ message, color: "yellow" });
@@ -55,7 +57,7 @@ export async function publish(
           );
 
           if (context.debug) {
-            console.log(`reading ${JSON.stringify(relativePath)}`);
+            console.error(`reading ${JSON.stringify(relativePath)}`);
           }
 
           const data = await Deno.readFile(path);
@@ -86,7 +88,7 @@ export async function publish(
   }
 
   if (context.debug) {
-    console.log("Manifest", manifest);
+    console.error("Manifest", manifest);
   }
 
   const trpcClient = createTrpcClient(context);
@@ -158,7 +160,7 @@ export async function publish(
     }
 
     if (context.debug) {
-      console.log("Missing hashes", missingHashes);
+      console.error("Missing hashes", missingHashes);
     }
 
     const useProgress = shouldUseSpinner(context);
@@ -208,7 +210,7 @@ export async function publish(
             }
 
             if (context.debug) {
-              console.log(
+              console.error(
                 `uploading ${JSON.stringify(internalPath)}`,
               );
             }
@@ -225,7 +227,7 @@ export async function publish(
         suffix: "debug.tar.gz",
       });
       await Deno.writeFile(path, tb2);
-      console.log(`Created debug tarball at '${path}'`);
+      console.error(`Created debug tarball at '${path}'`);
     }
 
     const resp = await authedFetch(
@@ -290,8 +292,10 @@ export async function waitForRevision(
   const quiet = context.quiet || context.json;
   const log: typeof console.log = quiet
     ? () => {}
+    // Status/progress chrome goes to stderr; stdout is reserved for the
+    // (--json) result payload.
     // deno-lint-ignore no-explicit-any
-    : console.log.bind(console) as any;
+    : console.error.bind(console) as any;
   const trpcClient = createTrpcClient(context);
 
   log(
@@ -351,7 +355,7 @@ export async function waitForRevision(
           `View ${context.endpoint}/${org}/${app}/builds/${revisionId} for details.`,
       });
     }
-    console.log(
+    console.error(
       `\n${red("✗")} The revision ${
         revision.status === "cancelled" ? "was " : ""
       }${revision.status}.\n  Please view the revision in the dashboard for more information.`,
@@ -390,10 +394,10 @@ export async function waitForRevision(
     return;
   }
 
-  console.log(`\n${green("✔")} Successfully deployed your application!`);
+  console.error(`\n${green("✔")} Successfully deployed your application!`);
 
   for (const timeline of timelines) {
-    console.log(
+    console.error(
       `${timeline.partition_config_name} url:${
         timeline.domains.map((domain) => `\n  https://${domain}`)
       }`,

--- a/deploy/publish.ts
+++ b/deploy/publish.ts
@@ -162,35 +162,40 @@ export async function publish(
     }
 
     const useProgress = shouldUseSpinner(context);
-    const progress = new ProgressBar({
-      max: missingHashes.length,
-      emptyChar: " ",
-      fillChar: green("█"),
-      formatter(formatter) {
-        const minutes = (formatter.time / 1000 / 60 | 0).toString().padStart(
-          2,
-          "0",
-        );
-        const seconds = (formatter.time / 1000 % 60 | 0).toString().padStart(
-          2,
-          "0",
-        );
+    // Only instantiate the bar when it will actually be drawn; otherwise its
+    // internal render timer keeps the event loop alive and the process hangs
+    // after we're done (e.g. under --json / --no-wait).
+    const progress = useProgress
+      ? new ProgressBar({
+        max: missingHashes.length,
+        emptyChar: " ",
+        fillChar: green("█"),
+        formatter(formatter) {
+          const minutes = (formatter.time / 1000 / 60 | 0).toString().padStart(
+            2,
+            "0",
+          );
+          const seconds = (formatter.time / 1000 % 60 | 0).toString().padStart(
+            2,
+            "0",
+          );
 
-        const length = formatter.max.toString().length;
-        return `[${yellow(minutes)}:${
-          yellow(seconds)
-        }] ${formatter.progressBar} ${
-          yellow(formatter.value.toString().padStart(length, " "))
-        }/${yellow(formatter.max.toString())} files uploaded.`;
-      },
-    });
+          const length = formatter.max.toString().length;
+          return `[${yellow(minutes)}:${
+            yellow(seconds)
+          }] ${formatter.progressBar} ${
+            yellow(formatter.value.toString().padStart(length, " "))
+          }/${yellow(formatter.max.toString())} files uploaded.`;
+        },
+      })
+      : undefined;
 
     let tarball = body
       .pipeThrough(
         new TransformStream({
           transform({ internalPath, data, hash }, controller) {
             if (missingHashes.includes(hash)) {
-              if (useProgress) progress.value += 1;
+              if (progress) progress.value += 1;
 
               controller.enqueue(
                 {
@@ -239,7 +244,7 @@ export async function publish(
       },
     );
 
-    if (useProgress) await progress.stop();
+    if (progress) await progress.stop();
 
     log();
 
@@ -257,6 +262,17 @@ export async function publish(
 
   if (wait) {
     await waitForRevision(context, org, app, revisionId, revision);
+  } else if (context.json) {
+    // Without --wait the build hasn't finished, so the production URL isn't
+    // known yet; still emit the revision id so agents can poll/track it.
+    writeJsonResult({
+      org,
+      app,
+      revisionId,
+      url: `${context.endpoint}/${org}/${app}/builds/${revisionId}`,
+      status: "pending",
+      productionUrl: null,
+    });
   } else {
     log(
       "To see the deployment, go to the revision page and wait for the build to complete.",
@@ -347,7 +363,16 @@ export async function waitForRevision(
     org,
     app,
     revision: revisionId,
-  }) as Array<{ partition_config_name: string; domains: string[] }>;
+  }) as Array<
+    { partition_config_name: string; context_name: string; domains: string[] }
+  >;
+
+  const productionTimeline =
+    timelines.find((t) => t.context_name === "Production") ??
+      timelines.find((t) => t.partition_config_name === "Production");
+  const productionUrl = productionTimeline?.domains[0]
+    ? `https://${productionTimeline.domains[0]}`
+    : null;
 
   if (context.json) {
     writeJsonResult({
@@ -356,6 +381,7 @@ export async function waitForRevision(
       revisionId,
       url: `${context.endpoint}/${org}/${app}/builds/${revisionId}`,
       status: revision?.status ?? "ready",
+      productionUrl,
       timelines: timelines.map((t) => ({
         partition: t.partition_config_name,
         domains: t.domains.map((d) => `https://${d}`),

--- a/deploy/publish.ts
+++ b/deploy/publish.ts
@@ -4,7 +4,12 @@ import { Spinner } from "@std/cli/unstable-spinner";
 import { join, relative, resolve, SEPARATOR } from "@std/path";
 import { green, red, yellow } from "@std/fmt/colors";
 import { authedFetch, createTrpcClient } from "../auth.ts";
-import { error, shouldUseSpinner, writeJsonResult } from "../util.ts";
+import {
+  error,
+  selectProductionUrl,
+  shouldUseSpinner,
+  writeJsonResult,
+} from "../util.ts";
 import type { GlobalContext } from "../main.ts";
 import type { ConfigContext } from "../config.ts";
 
@@ -371,12 +376,7 @@ export async function waitForRevision(
     { partition_config_name: string; context_name: string; domains: string[] }
   >;
 
-  const productionTimeline =
-    timelines.find((t) => t.context_name === "Production") ??
-      timelines.find((t) => t.partition_config_name === "Production");
-  const productionUrl = productionTimeline?.domains[0]
-    ? `https://${productionTimeline.domains[0]}`
-    : null;
+  const { productionUrl } = selectProductionUrl(timelines);
 
   if (context.json) {
     writeJsonResult({

--- a/util.ts
+++ b/util.ts
@@ -136,6 +136,31 @@ function exitCodeToName(code: ExitCode): string {
   }
 }
 
+/** Minimal shape of a revision timeline needed to locate production. */
+export interface ProductionTimelineLike {
+  partition_config_name: string;
+  context_name: string;
+  domains: string[];
+}
+
+/**
+ * Select the timeline that serves the app's production context and derive its
+ * public URL/domains. Centralized so the deploy flow and `apps get` can't drift
+ * on how "production" is identified or how domains are https-prefixed.
+ */
+export function selectProductionUrl<T extends ProductionTimelineLike>(
+  timelines: T[],
+): {
+  timeline: T | undefined;
+  domains: string[];
+  productionUrl: string | null;
+} {
+  const timeline = timelines.find((t) => t.context_name === "Production") ??
+    timelines.find((t) => t.partition_config_name === "Production");
+  const domains = (timeline?.domains ?? []).map((d) => `https://${d}`);
+  return { timeline, domains, productionUrl: domains[0] ?? null };
+}
+
 export function renderTemporalTimestamp(timestamp: string, hideDate = false) {
   function pad(n: number, width: number): string {
     return n.toString().padStart(width, "0");

--- a/util.ts
+++ b/util.ts
@@ -136,18 +136,13 @@ function exitCodeToName(code: ExitCode): string {
   }
 }
 
-/** Minimal shape of a revision timeline needed to locate production. */
 export interface ProductionTimelineLike {
   partition_config_name: string;
   context_name: string;
   domains: string[];
 }
 
-/**
- * Select the timeline that serves the app's production context and derive its
- * public URL/domains. Centralized so the deploy flow and `apps get` can't drift
- * on how "production" is identified or how domains are https-prefixed.
- */
+/** Select the production timeline and derive its https-prefixed domains + URL. */
 export function selectProductionUrl<T extends ProductionTimelineLike>(
   timelines: T[],
 ): {


### PR DESCRIPTION
Addresses #108 (machine-readable production URL) plus a related `apps list` bug.

## Changes

### Fix: `apps list` never forwarded `org`
`apps list --org <org>` resolved the org but omitted it from the
`apps.listByPage` query, so the backend rejected it with
`MALFORMED_REQUEST` ("org: expected string, received undefined"). Now the
resolved org slug is forwarded (matching `deployments list`). `orgs list`
takes no org and `deployments list` already forwarded it, so neither was
affected.

### Feat: `apps get` (#108)
`apps get --org <org> --app <app> --json` returns
`{ slug, productionUrl, domains, productionRevisionId, timelines, ... }`.
Domains live on revision timelines (not the app record), so we read the
latest revision's timelines and select the Production-context partition.
Apps with no deployment report `productionUrl: null`. A human-readable
table is shown in non-json mode.

### Feat: deploy `--json` (#108)
- `deno deploy --json` now includes an explicit `productionUrl` field
  (in addition to the existing builds-page `url` and `timelines`).
- `deno deploy --no-wait --json` previously emitted empty stdout; it now
  emits a JSON object with `revisionId` (status `pending`).
- Fixes a latent hang where the upload progress bar's render timer kept
  the event loop alive in `--json`/`--quiet` mode, so the process never
  exited.

## Verification (live, throwaway org)
- `apps list --org … --json` → exit 0, returns apps.
- `apps get … --json` → correct `productionUrl` + `domains` + `timelines`.
- `deploy --prod --json` → `productionUrl` present, status `routed`, URL
  serves HTTP 200, exit 0.
- `deploy --prod --no-wait --json` → emits `revisionId`, exit 0 (~1.7s).