### PR TITLE
refactor(cli): route success/status output to stderr

### DIFF
--- a/auth.ts
+++ b/auth.ts
@@ -448,7 +448,7 @@ export const tokenStorage = {
     } catch {
       if (!cannotInteractWithKeychain) {
         cannotInteractWithKeychain = true;
-        console.log(KEYCHAIN_WARNING);
+        console.error(KEYCHAIN_WARNING);
       }
     }
   },

--- a/deploy/create/mod.ts
+++ b/deploy/create/mod.ts
@@ -297,8 +297,8 @@ export const createCommand = new Command<GlobalContext>()
       const region = required(options.region, "region");
 
       if (!options.json) {
-        console.log("Using the following build configuration:");
-        console.log(renderBuildConfig(buildConfig satisfies BuildConfig));
+        console.error("Using the following build configuration:");
+        console.error(renderBuildConfig(buildConfig satisfies BuildConfig));
       }
 
       data = {
@@ -417,7 +417,7 @@ export async function createApp(
 
   const appUrl = `${context.endpoint}/${data.org}/${data.app}`;
   if (!context.json) {
-    console.log(`${green("✔")} Created app, view it at ${appUrl}`);
+    console.error(`${green("✔")} Created app, view it at ${appUrl}`);
   }
 
   // Local-source apps deploy via publish(), which emits its own JSON envelope
@@ -451,7 +451,7 @@ export async function createApp(
       source: "github",
     });
   } else {
-    console.log(
+    console.error(
       `You can view the revision here:\n  ${context.endpoint}/${data.org}/${data.app}/builds/${revisionId}\n`,
     );
   }
@@ -459,7 +459,7 @@ export async function createApp(
   if (wait) {
     await waitForRevision(context, data.org, data.app, revisionId);
   } else if (!context.json) {
-    console.log(
+    console.error(
       "To see the deployment, go to the revision page and wait for the build to complete.",
     );
   }

--- a/deploy/deployments.ts
+++ b/deploy/deployments.ts
@@ -76,7 +76,7 @@ const deploymentsListCommand = new Command<GlobalContext>()
     }
 
     if (res.items.length === 0) {
-      console.log("No deployments for this application.");
+      console.error("No deployments for this application.");
       return;
     }
 
@@ -93,7 +93,9 @@ const deploymentsListCommand = new Command<GlobalContext>()
     );
 
     if (res.nextCursor) {
-      console.log(`\nMore results available; pass --cursor ${res.nextCursor}`);
+      console.error(
+        `\nMore results available; pass --cursor ${res.nextCursor}`,
+      );
     }
   }));
 

--- a/deploy/mod.ts
+++ b/deploy/mod.ts
@@ -236,7 +236,7 @@ const logoutCommand = new Command()
   .description("Revoke the Deno Deploy token if one is present")
   .action(() => {
     tokenStorage.remove();
-    console.log(`${green("✔")} Successfully logged out`);
+    console.error(`${green("✔")} Successfully logged out`);
   });
 
 interface WhoamiOrg {
@@ -296,7 +296,7 @@ const whoamiCommand = new Command<GlobalContext>()
         ? `@${me.user.githubLogin}`
         : me.user.email ?? me.user.name ?? me.user.id)
       : `org-scoped token (${me.tokenType})`;
-    console.log(
+    console.error(
       `${
         green("✔")
       } Authenticated as ${who}. ${orgs.length} reachable organization${

--- a/deploy/orgs.ts
+++ b/deploy/orgs.ts
@@ -30,7 +30,7 @@ const orgsListCommand = new Command<GlobalContext>()
     }
 
     if (orgs.length === 0) {
-      console.log("No organizations accessible with this token.");
+      console.error("No organizations accessible with this token.");
       return;
     }
 

--- a/tests/create.test.ts
+++ b/tests/create.test.ts
@@ -9,8 +9,7 @@ if (!Deno.env.get("DENO_DEPLOY_TOKEN")) {
 const deploy = async (...args: string[]) => {
   const escaped = args.map((a) => $.escapeArg(a)).join(" ");
   console.log(`deno deploy ${escaped}`);
-  // Status output (e.g. the build-config echo) goes to stderr per the CLI's
-  // stdout-discipline convention, so inspect the combined streams here.
+  // build-config echo is on stderr; inspect combined streams
   const result = await $.raw`deno deploy ${escaped}`
     .stderr("piped").stdout("piped");
   return (result.stdout + result.stderr).trim();

--- a/tests/create.test.ts
+++ b/tests/create.test.ts
@@ -9,7 +9,11 @@ if (!Deno.env.get("DENO_DEPLOY_TOKEN")) {
 const deploy = async (...args: string[]) => {
   const escaped = args.map((a) => $.escapeArg(a)).join(" ");
   console.log(`deno deploy ${escaped}`);
-  return (await $.raw`deno deploy ${escaped}`.text()).trim();
+  // Status output (e.g. the build-config echo) goes to stderr per the CLI's
+  // stdout-discipline convention, so inspect the combined streams here.
+  const result = await $.raw`deno deploy ${escaped}`
+    .stderr("piped").stdout("piped");
+  return (result.stdout + result.stderr).trim();
 };
 
 const deployFail = async (...args: string[]) => {


### PR DESCRIPTION
## What

Generalizes the CLI's stdout-discipline convention (previously documented for `--json` only) to **human mode too**. The rule is now uniform across all commands and both modes:

- **stdout** carries **only data payloads** — in `--json` the single JSON result object; in human mode the actual data a user would pipe (list/query tables, identity dumps).
- **All success / confirmation / status / empty-state messages** go to **stderr** via `console.error`, in both `--json` and human modes.

## Files in this PR (orphan files not owned by an in-flight PR)

- `deploy/create/mod.ts` — "Using the following build configuration", "✔ Created app …", revision-URL info, and the post-create "go to the revision page" hint → stderr.
- `deploy/mod.ts` — `whoami` "✔ Authenticated as …" confirmation → stderr (the orgs **table stays on stdout** as data); `logout` "✔ Successfully logged out" → stderr. The `logs` region is untouched (sibling PR).
- `deploy/orgs.ts` — "No organizations accessible with this token." empty-state → stderr (list data stays on stdout).
- `deploy/deployments.ts` — "No deployments for this application." empty-state and "More results available; pass --cursor …" pagination hint → stderr (list data stays on stdout).

## Covered by sibling PRs (not touched here)

`config.ts` (#118 — config-file-creation + "Selected org/app" messages), `deploy/env.ts` (#119), `deploy/database.ts` (#117), `deploy/setup-cloud.ts` (#115), `main.ts`/`switch` (#116), `deploy/apps.ts` + `deploy/publish.ts` (#121), `sandbox/*` (#118).

## Verification

`deno fmt --check`, `deno lint`, `deno check` all pass. Live-checked against a throwaway org/app:
- `orgs list` / `deployments list` (human + `--json`): data on stdout, stderr clean.
- `create --dry-run` (human): build-config echo on stderr, stdout empty; (`--json`): single JSON object on stdout, stderr empty.
- `whoami` (human): orgs table on stdout, "✔ Authenticated as …" on stderr; (`--json`): single object on stdout, stderr empty.
- `logout`: confirmation on stderr.