### PR TITLE
fix: exit cleanly after a successful deploy (process hangs until CI timeout)

### DIFF
--- a/deploy/mod.ts
+++ b/deploy/mod.ts
@@ -248,6 +248,15 @@ deploy your local directory to the specified application.`)
             options.wait ?? true,
           );
         }
+
+        // The deploy has finished successfully. Force a clean exit: the tRPC
+        // client used for the upload/`revisions.watchUntilReady` subscription
+        // keeps handles open (the EventSource polyfill's connection + reconnect
+        // timer, and the streaming upload request), so without this the process
+        // hangs indefinitely after printing "Successfully deployed" — turning a
+        // successful deploy into a job that runs until its CI timeout. Mirrors
+        // the explicit `Deno.exit(1)` on the failure path in publish.ts.
+        Deno.exit(0);
       },
       (rootPath) => rootPath,
     ),


### PR DESCRIPTION
## Problem

After a successful `deno deploy`, the CLI **prints the success message but the process never exits**:

```
✔ Successfully deployed your application!
Production url:
  https://<app>.<org>.deno.net
```

…and then the process just hangs (the `files uploaded` / `Awaiting revision` spinner keeps ticking) until it is killed externally.

In CI this turns a **successful** deploy into a **failed** job: the site deploys and goes live, but the workflow keeps running until it hits `timeout-minutes` and GitHub cancels it with `The operation was canceled`. A real example: the deploy completed and the URL served HTTP 200, yet the Actions run was red after running the full 10 minutes doing nothing.

## Cause

The deploy path builds a tRPC client (`createTrpcClient`) that is used for the streaming upload (`httpBatchStreamLink`) and, when waiting, the `revisions.watchUntilReady` subscription (`httpSubscriptionLink` backed by the `event-source-polyfill`). None of these are ever disposed, so open handles (the EventSource connection + its reconnect timer, and the streaming upload request) keep the Deno event loop alive after the work is done. `--no-wait` does **not** avoid it — the upload path leaks too.

Notably the **failure** path already calls `Deno.exit(1)` explicitly (`deploy/publish.ts`), so only the **success** path is affected.

## Fix

Explicitly `Deno.exit(0)` once the deploy action finishes successfully, mirroring the existing `Deno.exit(1)` on failure. This is a one-line, low-risk change scoped to the top-level `deploy` action (it does not affect other subcommands).

## Verification (against production)

Same app, same command, same runtime (deno 2.9.1):

- **Unpatched:** prints `✔ Successfully deployed`, then hangs — killed at 10 min in CI (`The operation was canceled`) and reproduced locally as EXIT 124 under `timeout`.
- **Patched:** prints `✔ Successfully deployed`, then **exits 0 in ~30s**. The failure path still exits 1 as before.