### PR TITLE
fix: exit cleanly after a successful deploy (#125)

### DIFF
--- a/deploy/mod.ts
+++ b/deploy/mod.ts
@@ -424,6 +424,19 @@ for the full reference.`)
             options.wait ?? true,
           );
         }
+
+        // Persist resolved org/app now; actionHandler's post-action save()
+        // would otherwise be skipped by the forced exit below.
+        await config.save();
+
+        // The deploy has finished successfully. Force a clean exit: the tRPC
+        // client used for the upload/`revisions.watchUntilReady` subscription
+        // keeps handles open (the EventSource polyfill's connection + reconnect
+        // timer, and the streaming upload request), so without this the process
+        // hangs indefinitely after printing "Successfully deployed" — turning a
+        // successful deploy into a job that runs until its CI timeout. Mirrors
+        // the explicit `Deno.exit(1)` on the failure path in publish.ts.
+        Deno.exit(0);
       },
       (rootPath) => rootPath,
     ),


### PR DESCRIPTION
Lands #125 by @uriva, rebased onto main as a single commit with one
addition: `await config.save()` before the forced exit. `Deno.exit(0)`
otherwise skips actionHandler's post-action save, so first-run org/app
persistence to deno.json would be lost.

* deploy: force a clean exit after a successful deploy; the tRPC
  client's EventSource polyfill connection/reconnect timer and the
  streaming upload otherwise keep the event loop alive and the process
  hangs until its CI timeout
* mirrors the explicit Deno.exit(1) on the failure path

Will be rebase-merged to preserve the original author.

Closes #125.