### PR TITLE
ci: run rs_lib cargo tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
       - name: check
         run: deno check
 
+      - name: rust tests
+        run: cargo test -p rs_lib
+
       - name: run tests
         env:
           DENO_DEPLOY_TOKEN: ${{ secrets.DENO_DEPLOY_TOKEN }}


### PR DESCRIPTION
The rs_lib unit tests (workspace include, positional file root, and
Windows path normalization regressions from #99/#114/#124) are
host-target cargo tests that `deno test` never executes, so CI has
been skipping them. Add a `cargo test -p rs_lib` step to the deno job.