### PR TITLE
fix(sandbox): load @deno/sandbox lazily

### DIFF
--- a/sandbox/api.ts
+++ b/sandbox/api.ts
@@ -1,0 +1,16 @@
+/**
+ * Loads `@deno/sandbox` lazily, at command run time.
+ *
+ * The `deno deploy` subcommand executes this package with the user's
+ * workspace config applied, so an eager import would make Deno consider a
+ * workspace member named `@deno/sandbox` for the CLI's own module graph: a
+ * member whose version satisfies the constraint gets linked in place of the
+ * published package, and a non-matching one emits a "Workspace member ...
+ * was not used" warning — for every command, even ones that never touch
+ * sandboxes. Keeping the import dynamic confines both effects to the
+ * `sandbox` subcommands. Type-only imports of `@deno/sandbox` are erased at
+ * runtime and remain safe anywhere.
+ */
+export function sandboxApi(): Promise<typeof import("@deno/sandbox")> {
+  return import("@deno/sandbox");
+}

--- a/sandbox/mod.ts
+++ b/sandbox/mod.ts
@@ -1,10 +1,6 @@
 import { Command, ValidationError } from "@cliffy/command";
-import {
-  type Region,
-  Sandbox,
-  type VolumeId,
-  type VolumeSlug,
-} from "@deno/sandbox";
+import type { Region, Sandbox, VolumeId, VolumeSlug } from "@deno/sandbox";
+import { sandboxApi } from "./api.ts";
 import { green, magenta, red, setColorEnabled, yellow } from "@std/fmt/colors";
 import { pooledMap } from "@std/async";
 import { expandGlob } from "@std/fs";
@@ -119,6 +115,7 @@ export const sandboxCreateCommand = new Command<SandboxContext>()
       memory = Math.floor(parseSize(options, options.memory));
     }
 
+    const { Sandbox } = await sandboxApi();
     const sandbox = await Sandbox.create({
       debug: options.debug,
       token,
@@ -613,6 +610,7 @@ async function connectToSandbox(
   const org = await getOrg(options, config, options.org);
   const token = await getAuth(options, true);
 
+  const { Sandbox } = await sandboxApi();
   return await Sandbox.connect({
     id: sandboxId,
     apiEndpoint: options.endpoint,

--- a/sandbox/snapshot.ts
+++ b/sandbox/snapshot.ts
@@ -1,7 +1,7 @@
 import { Command } from "@cliffy/command";
 import type { SandboxContext } from "./mod.ts";
 import { getAuth } from "../auth.ts";
-import { Client } from "@deno/sandbox";
+import { sandboxApi } from "./api.ts";
 import { formatSize, tablePrinter, writeJsonResult } from "../util.ts";
 import { green } from "@std/fmt/colors";
 import { actionHandler, getOrg } from "../config.ts";
@@ -14,6 +14,8 @@ export const snapshotsCreateCommand = new Command<SandboxContext>()
       config.noCreate();
       const org = await getOrg(options, config, options.org);
       const token = await getAuth(options, true);
+
+      const { Client } = await sandboxApi();
 
       const client = new Client({
         apiEndpoint: options.endpoint,
@@ -39,6 +41,8 @@ export const snapshotsListCommand = new Command<SandboxContext>()
     config.noCreate();
     const org = await getOrg(options, config, options.org);
     const token = await getAuth(options, true);
+
+    const { Client } = await sandboxApi();
 
     const client = new Client({
       apiEndpoint: options.endpoint,
@@ -91,6 +95,8 @@ export const snapshotsDeleteCommand = new Command<SandboxContext>()
     config.noCreate();
     const org = await getOrg(options, config, options.org);
     const token = await getAuth(options, true);
+
+    const { Client } = await sandboxApi();
 
     const client = new Client({
       apiEndpoint: options.endpoint,

--- a/sandbox/volumes.ts
+++ b/sandbox/volumes.ts
@@ -1,7 +1,7 @@
 import { Command } from "@cliffy/command";
 import type { SandboxContext } from "./mod.ts";
 import { getAuth } from "../auth.ts";
-import { Client } from "@deno/sandbox";
+import { sandboxApi } from "./api.ts";
 import {
   formatSize,
   parseSize,
@@ -27,6 +27,8 @@ export const volumesCreateCommand = new Command<SandboxContext>()
 
     const org = await getOrg(options, config, options.org);
     const token = await getAuth(options, true);
+
+    const { Client } = await sandboxApi();
 
     const client = new Client({
       apiEndpoint: options.endpoint,
@@ -56,6 +58,8 @@ export const volumesListCommand = new Command<SandboxContext>()
 
     const org = await getOrg(options, config, options.org);
     const token = await getAuth(options, true);
+
+    const { Client } = await sandboxApi();
 
     const client = new Client({
       apiEndpoint: options.endpoint,
@@ -108,6 +112,8 @@ export const volumesDeleteCommand = new Command<SandboxContext>()
     const org = await getOrg(options, config, options.org);
     const token = await getAuth(options, true);
 
+    const { Client } = await sandboxApi();
+
     const client = new Client({
       apiEndpoint: options.endpoint,
       token,
@@ -131,6 +137,8 @@ export const volumesSnapshotCommand = new Command<SandboxContext>()
 
       const org = await getOrg(options, config, options.org);
       const token = await getAuth(options, true);
+
+      const { Client } = await sandboxApi();
 
       const client = new Client({
         apiEndpoint: options.endpoint,

--- a/tests/lazy_sandbox.test.ts
+++ b/tests/lazy_sandbox.test.ts
@@ -1,0 +1,54 @@
+import { assert } from "@std/assert";
+import { fromFileUrl } from "@std/path";
+
+// `deno deploy` runs this package with the user's workspace config applied,
+// so an eager (static, non-type) import of @deno/sandbox would let a
+// workspace member named @deno/sandbox be linked into the CLI's module graph
+// (or emit a "workspace member was not used" warning) for every command.
+// Assert that first-party code only reaches @deno/sandbox through dynamic
+// imports; type-only imports are erased at runtime and are fine.
+
+const MAIN_TS = fromFileUrl(new URL("../main.ts", import.meta.url));
+
+interface InfoDependency {
+  specifier: string;
+  isDynamic?: boolean;
+  code?: { specifier?: string };
+}
+
+interface InfoModule {
+  specifier: string;
+  dependencies?: InfoDependency[];
+}
+
+Deno.test("@deno/sandbox is not in the CLI's eager module graph", async () => {
+  const { code, stdout, stderr } = await new Deno.Command(Deno.execPath(), {
+    args: ["info", "--json", MAIN_TS],
+    stdout: "piped",
+    stderr: "piped",
+  }).output();
+  assert(code === 0, new TextDecoder().decode(stderr));
+
+  const graph = JSON.parse(new TextDecoder().decode(stdout)) as {
+    modules: InfoModule[];
+  };
+
+  const offenders: string[] = [];
+  for (const mod of graph.modules) {
+    // Only first-party modules matter; edges inside the @deno/sandbox
+    // package itself are unreachable unless the dynamic import runs.
+    if (!mod.specifier.startsWith("file://")) continue;
+    for (const dep of mod.dependencies ?? []) {
+      const target = dep.code?.specifier ?? "";
+      if (target.includes("@deno/sandbox") && !dep.isDynamic) {
+        offenders.push(`${mod.specifier} -> ${target}`);
+      }
+    }
+  }
+
+  assert(
+    offenders.length === 0,
+    `static @deno/sandbox import(s) found (use sandbox/api.ts's lazy ` +
+      `sandboxApi() or an \`import type\` instead):\n${offenders.join("\n")}`,
+  );
+});


### PR DESCRIPTION
`deno deploy` executes this package with the user's workspace config
applied (the subcommand disables the lockfile and node_modules, but not
config discovery), so the CLI's static import of @deno/sandbox made
Deno consider a workspace member named @deno/sandbox for the CLI's own
module graph. Inside such a workspace (e.g. the sandbox repo itself)
every command either emitted

    Warning Workspace member '@deno/sandbox@x.y.z' was not used because
    it did not match '@deno/sandbox@^...'

or, when the member's version satisfied the constraint, linked the
local package into the CLI and crashed it outright (reproduced:
"does not provide an export named 'Client'").

* import @deno/sandbox only via a dynamic import in sandbox/api.ts,
  executed when a sandbox command actually runs; value uses in
  create/connect/volumes/snapshot go through it
* remaining references are `import type`, which is erased at runtime
  and never resolved by the module loader
* adds a regression test asserting no first-party module has a static
  code edge to @deno/sandbox (via deno info --json)

Non-sandbox commands now run with zero @deno/sandbox resolution, so
neither the warning nor the linking can occur for them. The sandbox
subcommands still resolve it at run time; full isolation needs the
deno subcommand to disable config discovery for the jsr-fetched CLI.