### PR TITLE
0.0.9904

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -4,7 +4,7 @@
     "astro-demo"
   ],
   "name": "@deno/deploy",
-  "version": "0.0.9903",
+  "version": "0.0.9904",
   "license": "MIT",
   "tasks": {
     "build": "deno run -A jsr:@deno/wasmbuild@0.19.2"


### PR DESCRIPTION
Bumps the version in `deno.json` to `0.0.9904`.

Note: CI on this branch is expected to fail the `run tests` step. Two tests in `tests/cli_contract.test.ts` are already failing on `main` (see [run 29055213392](https://github.com/denoland/deploy-cli/actions/runs/29055213392)) and are unrelated to this version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)