### PR TITLE
fix(config): stop appending blank lines

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -395,7 +395,7 @@ async function writeConfig(
 
   await Deno.writeTextFile(
     configContent.config?.path ?? join(Deno.cwd(), "deno.jsonc"),
-    config.toString() + "\n",
+    config.toString(),
   );
 
   if (!configContent.config) {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -95,6 +95,29 @@ Deno.test("deploy preserves comments and formatting (jsonc)", async () => {
   assertStringIncludes(out, "// and this one");
 });
 
+Deno.test("deploy does not append a blank line on repeated updates", async () => {
+  const input = `{
+  "deploy": {
+    "org": "old-org",
+    "app": "my-app"
+  }
+}
+`;
+  const expected = `{
+  "deploy": {
+    "org": "my-org",
+    "app": "my-app"
+  }
+}
+`;
+
+  const once = await runDeploy(input, { org: "my-org", app: "my-app" });
+  const twice = await runDeploy(once, { org: "my-org", app: "my-app" });
+
+  assertEquals(once, expected);
+  assertEquals(twice, expected);
+});
+
 // Regression: a read-only command (one that never touches `config.files`) must
 // NOT trigger the recursive deploy-manifest file walk. Before the lazy-`files`
 // fix, `actionHandler` eagerly walked the whole working directory, so commands


### PR DESCRIPTION
# Summary

## Problem

After #103, config updates preserve existing `deploy` fields, but each update adds an extra empty line to `deno.json`. This leaves the Git working tree dirty after every deployment.

## Changes

Write the output from `jsonc-morph` directly, since it already preserves the config's trailing whitespace.

## Tests

Added a regression test that updates the same config twice and verifies that no blank lines accumulate.